### PR TITLE
Added 2 commands:

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsCreateCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsCreateCommand.cs
@@ -1,9 +1,11 @@
 ﻿
 namespace Greg.Xrm.Command.Commands.WebResources
 {
-	[Command("webresources", "create", "js", HelpText = "(Preview) Creates a new Javascript webresource from a template")]
+	[Command("webresources", "js", "create", HelpText = "(Preview) Creates a new Javascript webresource from a template")]
+	[Alias("wr", "js", "create")]
 	[Alias("wr", "create", "js")]
-	public class CreateJsCommand
+	[Alias("wr", "create", "js")]
+	public class JsCreateCommand
 	{
 		[Option("for", "f", HelpText = "Indicates if the JS web resource to create is for a form, a ribbon command, or other", DefaultValue = JavascriptWebResourceType.Form)]
 		public JavascriptWebResourceType Type { get; set; } = JavascriptWebResourceType.Form;

--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsCreateCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsCreateCommandExecutor.cs
@@ -7,14 +7,14 @@ using Greg.Xrm.Command.Model;
 
 namespace Greg.Xrm.Command.Commands.WebResources
 {
-    public class CreateJsCommandExecutor : ICommandExecutor<CreateJsCommand>
+    public class JsCreateCommandExecutor : ICommandExecutor<JsCreateCommand>
 	{
 		private readonly IOutput output;
 		private readonly IOrganizationServiceRepository organizationServiceRepository;
 		private readonly ISolutionRepository solutionRepository;
 		private readonly IJsTemplateManager jsTemplateManager;
 
-		public CreateJsCommandExecutor(
+		public JsCreateCommandExecutor(
 			IOutput output,
 			IOrganizationServiceRepository organizationServiceRepository,
 			ISolutionRepository solutionRepository,
@@ -26,7 +26,7 @@ namespace Greg.Xrm.Command.Commands.WebResources
 			this.jsTemplateManager = jsTemplateManager ?? throw new ArgumentNullException(nameof(jsTemplateManager));
 		}
 
-        public async Task<CommandResult> ExecuteAsync(CreateJsCommand command, CancellationToken cancellationToken)
+        public async Task<CommandResult> ExecuteAsync(JsCreateCommand command, CancellationToken cancellationToken)
 		{
 			// devo navigare l'albero delle cartelle per trovare la cartella radice del mio pacchetto di webresource
 			// (è la cartella che contiene il file .wr.pacx). 
@@ -88,7 +88,7 @@ namespace Greg.Xrm.Command.Commands.WebResources
 
 
 
-		private async Task<CommandResult> CreateFileAsync(CreateJsCommand command, IOrganizationServiceAsync2 crm, DirectoryInfo directory, CancellationToken cancellationToken)
+		private async Task<CommandResult> CreateFileAsync(JsCreateCommand command, IOrganizationServiceAsync2 crm, DirectoryInfo directory, CancellationToken cancellationToken)
 		{
 			if (command.Type == JavascriptWebResourceType.Form && string.IsNullOrWhiteSpace(command.TableName))
 			{
@@ -146,7 +146,7 @@ namespace Greg.Xrm.Command.Commands.WebResources
 
 
 
-		private static string CreateFileName(CreateJsCommand command)
+		private static string CreateFileName(JsCreateCommand command)
 		{
 			if (command.Type == JavascriptWebResourceType.Form)
 			{

--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsResetTemplateCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsResetTemplateCommand.cs
@@ -1,0 +1,50 @@
+﻿using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.WebResources
+{
+	[Command("webresources", "js", "resetTemplate", HelpText = "Allows to restore the default templates used for JS WebResources to the one shipped by default by PACX.")]
+	[Alias("wr", "js", "resetTemplate")]
+	[Alias("wr", "resetTemplate", "js")]
+	public class JsResetTemplateCommand : ICanProvideUsageExample
+	{
+		[Option("type", "t", HelpText = "The type of the template to restore.", DefaultValue = JavascriptWebResourceType.Form)]
+		[Required(ErrorMessage = "The template type is required")]
+		public JavascriptWebResourceType Type { get; set; } = JavascriptWebResourceType.Form;
+
+		[Option("forTable", "ft", HelpText = "To be used in conjunction with `--type Ribbon`, indicates if the template is for a table command bar. If not specified, is assumed as a global command bar.", DefaultValue = false)]
+		public bool ForTable { get; set; }
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("This command can be used whenever you have overridden the default templates used to create JS WebResources via `pacx webresources js setTemplate` and you want to restore the default templates shipped by PACX. The command will restore the default templates for the specified type.");
+			writer.WriteParagraph("The default templates are: ");
+
+			writer.WriteTitle3("Form");
+
+			writer.WriteCodeBlockStart("Javascript");
+			writer.WriteLine(Properties.Resources.TemplateJsForm);
+			writer.WriteCodeBlockEnd().WriteLine();
+
+			writer.WriteTitle3("Ribbon (command bar) - Table-related");
+
+			writer.WriteCodeBlockStart("Javascript");
+			writer.WriteLine(Properties.Resources.TemplateJsRibbonTable);
+			writer.WriteCodeBlockEnd().WriteLine();
+
+			writer.WriteTitle3("Ribbon (command bar) - Global");
+
+			writer.WriteCodeBlockStart("Javascript");
+			writer.WriteLine(Properties.Resources.TemplateJsRibbonGlobal);
+			writer.WriteCodeBlockEnd().WriteLine();
+
+			writer.WriteTitle3("Other");
+
+			writer.WriteCodeBlockStart("Javascript");
+			writer.WriteLine(Properties.Resources.TemplateJsOther);
+			writer.WriteCodeBlockEnd().WriteLine();
+
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsResetTemplateCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsResetTemplateCommandExecutor.cs
@@ -1,0 +1,29 @@
+﻿using Greg.Xrm.Command.Commands.WebResources.Templates;
+using Greg.Xrm.Command.Services.Output;
+
+namespace Greg.Xrm.Command.Commands.WebResources
+{
+	public class JsResetTemplateCommandExecutor : ICommandExecutor<JsResetTemplateCommand>
+	{
+		private readonly IOutput output;
+		private readonly IJsTemplateManager jsTemplateManager;
+
+		public JsResetTemplateCommandExecutor(
+			IOutput output,
+			IJsTemplateManager jsTemplateManager)
+		{
+			this.output = output;
+			this.jsTemplateManager = jsTemplateManager;
+		}
+
+		public async Task<CommandResult> ExecuteAsync(JsResetTemplateCommand command, CancellationToken cancellationToken)
+		{
+			this.output.Write("Resetting default template...");
+			var global = command.Type == JavascriptWebResourceType.Ribbon && !command.ForTable;
+			await this.jsTemplateManager.ResetTemplateForAsync(command.Type, global);
+			this.output.WriteLine("DONE", ConsoleColor.Green);
+
+			return CommandResult.Success();
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsSetTemplateCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsSetTemplateCommand.cs
@@ -1,0 +1,50 @@
+﻿using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.WebResources
+{
+    [Command("webresources", "js", "setTemplate", HelpText = "Allows to override the default template used when creating custom JS WebResources.")]
+	[Alias("wr", "js", "setTemplate")]
+	[Alias("wr", "setTemplate", "js")]
+	public class JsSetTemplateCommand : ICanProvideUsageExample, IValidatableObject
+	{
+		[Option("file", "f", HelpText = "The name of the file that contains the new template")]
+		[Required]
+		public string FileName { get; set; } = string.Empty;
+
+		[Option("type", "t", HelpText = "The type of the template to override.", DefaultValue = JavascriptWebResourceType.Form)]
+		public JavascriptWebResourceType Type { get; set; } = JavascriptWebResourceType.Form;
+
+		[Option("forTable", "ft", HelpText = "To be used in conjunction with `--type Ribbon`, indicates if the template is for a table command bar. If not specified, is assumed as a global command bar.", DefaultValue = false)]
+		public bool ForTable { get; set; }
+
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("This command can be used to override the default templates used to create JS WebResources via `pacx webresources js create`.");
+
+			writer.WriteParagraph("PACX supports 4 different types of templates:");
+
+			writer.WriteList(
+				"**Form**: Used to create JS WebResources meant to be used in forms. (`pacx webresources js setTemplate --type Form --file ...`)",
+				"**Ribbon (global)**: Used to create JS WebResources meant to be used in global command bars. (`pacx webresources js setTemplate --type Ribbon --file ...`)",
+				"**Ribbon (table)**: Used to create JS WebResources meant to be used in specific table-related command bars. ( (`pacx webresources js setTemplate --type Ribbon --forTable --file ...`)",
+				"**Other**: Generic template for other types of JS WebResources. (`pacx webresources js setTemplate --type Other --file ...`)");
+
+			writer.WriteParagraph("Custom templates may contain 2 dynamic placeholders, that will be replaced with `pacx wr create js` command options:");
+
+			writer.WriteList(
+				"**%NAMESPACE%**: will be replaced with the value of `--namespace` option;",
+				"**%TABLE%**: will be replaced with the value of `--table` option;"
+			);
+		}
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			if (!File.Exists(this.FileName))
+			{
+				yield return new ValidationResult($"The specified file <{FileName}> does not exist", new[] { nameof(this.FileName) });
+			}
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/WebResources/JsSetTemplateCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/JsSetTemplateCommandExecutor.cs
@@ -1,0 +1,43 @@
+﻿using Greg.Xrm.Command.Commands.WebResources.Templates;
+using Greg.Xrm.Command.Services.Output;
+
+namespace Greg.Xrm.Command.Commands.WebResources
+{
+    public class JsSetTemplateCommandExecutor : ICommandExecutor<JsSetTemplateCommand>
+	{
+		private readonly IOutput output;
+		private readonly IJsTemplateManager jsTemplateManager;
+
+		public JsSetTemplateCommandExecutor(
+			IOutput output,
+			IJsTemplateManager jsTemplateManager)
+        {
+			this.output = output;
+			this.jsTemplateManager = jsTemplateManager;
+		}
+
+
+        public async Task<CommandResult> ExecuteAsync(JsSetTemplateCommand command, CancellationToken cancellationToken)
+		{
+			string templateContent;
+			try
+			{
+				this.output.Write("Reading template contents...");
+				templateContent = await File.ReadAllTextAsync(command.FileName, cancellationToken);
+				this.output.WriteLine("DONE", ConsoleColor.Green);
+			}
+			catch(Exception ex)
+			{
+				this.output.WriteLine("ERROR", ConsoleColor.Red);
+				return CommandResult.Fail("Error while trying to read the template file contents: " + ex.Message, ex);
+			}
+
+			this.output.Write("Updating default template...");
+			var global = command.Type == JavascriptWebResourceType.Ribbon && !command.ForTable;
+			await this.jsTemplateManager.SetTemplateForAsync(command.Type, global, templateContent);
+			this.output.WriteLine("DONE", ConsoleColor.Green);
+
+			return CommandResult.Success();
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/WebResources/Templates/IJsTemplateManager.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/Templates/IJsTemplateManager.cs
@@ -3,5 +3,9 @@
 	public interface IJsTemplateManager
 	{
 		Task<string> GetTemplateForAsync(JavascriptWebResourceType type, bool global);
+
+		Task SetTemplateForAsync(JavascriptWebResourceType type, bool global, string template);
+
+		Task ResetTemplateForAsync(JavascriptWebResourceType type, bool global);
 	}
 }

--- a/Greg.Xrm.Command.Core/Commands/WebResources/Templates/JsTemplateManager.cs
+++ b/Greg.Xrm.Command.Core/Commands/WebResources/Templates/JsTemplateManager.cs
@@ -14,7 +14,7 @@ namespace Greg.Xrm.Command.Commands.WebResources.Templates
 
 		public async Task<string> GetTemplateForAsync(JavascriptWebResourceType type, bool global)
 		{
-			var templateTypeName = "Template.Js." + type.ToString();
+			var templateTypeName = GetTemplateName(type, global);
 
 			var template = await this.settingsRepository.GetAsync<string>(templateTypeName);
 			if (string.IsNullOrWhiteSpace(template))
@@ -25,7 +25,26 @@ namespace Greg.Xrm.Command.Commands.WebResources.Templates
 			return template;
 		}
 
+		public async Task SetTemplateForAsync(JavascriptWebResourceType type, bool global, string template)
+		{
+			var templateTypeName = GetTemplateName(type, global);
 
+			await this.settingsRepository.SetAsync(templateTypeName, template);
+		}
+
+		public async Task ResetTemplateForAsync(JavascriptWebResourceType type, bool global)
+		{
+			var templateTypeName = GetTemplateName(type, global);
+			var template = GetDefaultTemplateFor(type, global);
+
+			await this.settingsRepository.SetAsync(templateTypeName, template);
+		}
+
+		private static string GetTemplateName(JavascriptWebResourceType type, bool global)
+		{
+			var globalSuffix = global ? ".global" : string.Empty;
+			return $"Template.Js.{type}{globalSuffix}";
+		}
 
 		private static string GetDefaultTemplateFor(JavascriptWebResourceType type, bool global)
 		{
@@ -48,5 +67,6 @@ namespace Greg.Xrm.Command.Commands.WebResources.Templates
 
 			throw new NotSupportedException($"The web resource type <{type}> is not supported.");
 		}
+
 	}
 }


### PR DESCRIPTION
Added 2 commands:
- webresources js setTemplate
- webresources js resetTemplate

To allow developers to change the default template used to create webresources

Moreover, the name of the "webresources create js" command has been changed to "webresources js create". An alias has been added to allow for backward compatibility