### PR TITLE
Update command usage examples for consistency

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Script/ScriptAllCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/ScriptAllCommand.cs
@@ -28,7 +28,9 @@ namespace Greg.Xrm.Command.Commands.Script
             writer.WriteParagraph("This command generates PACX scripts for all entities with the specified custom prefixes.");
             writer.WriteParagraph("If requested, the generated CSV file will contain only the statecode and statuscode fields for each entity, for documentation purposes.");
             writer.WriteParagraph("Example usage:");
-            writer.WriteCodeBlock("pacx script all --customPrefixs \"custom_\" --output \"C:/output\" --pacxScriptName \"myscript.ps1\" --stateFieldsDefinitionName \"state-fields.csv\" --withStateFieldsDefinition true", "PowerShell");
+            writer.WriteCodeBlock(
+                "pacx script all --customPrefixs \"custom_\" --output \"C:/output\" --scriptFileName \"myscript.ps1\" --stateFileName \"state-fields.csv\" --includeStateFields",
+                "PowerShell");
         }
     }
 }

--- a/Greg.Xrm.Command.Core/Commands/Script/ScriptSolutionCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/ScriptSolutionCommand.cs
@@ -32,7 +32,9 @@ namespace Greg.Xrm.Command.Commands.Script
             writer.WriteParagraph("This command generates PACX scripts for all tables in one or more PowerApps solutions.");
             writer.WriteParagraph("If requested, the generated CSV file will contain only the statecode and statuscode fields for each entity, for documentation purposes.");
             writer.WriteParagraph("Example usage:");
-            writer.WriteCodeBlock("pacx script solution --solutionNames \"Solution1,Solution2\" --customPrefixs \"custom_\" --output \"C:/output\" --pacxScriptName \"myscript.ps1\" --stateFieldsDefinitionName \"state-fields.csv\" --withStateFieldsDefinition true", "PowerShell");
+            writer.WriteCodeBlock(
+                "pacx script solution --solutionNames \"Solution1,Solution2\" --customPrefixs \"custom_\" --output \"C:/output\" --scriptFileName \"myscript.ps1\" --stateFileName \"state-fields.csv\" --includeStateFields",
+                "PowerShell");
         }
     }
 }

--- a/Greg.Xrm.Command.Core/Commands/Script/ScriptTableCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/ScriptTableCommand.cs
@@ -34,7 +34,9 @@ namespace Greg.Xrm.Command.Commands.Script
             writer.WriteParagraph("This command generates a PACX script for a single table.");
             writer.WriteParagraph("If requested, the generated CSV file will contain only the statecode and statuscode fields for the entity, for documentation purposes.");
             writer.WriteParagraph("Example usage:");
-            writer.WriteCodeBlock("pacx script table --tableName \"account\" --customPrefixs \"custom_\" --output \"C:/output\" --pacxScriptName \"myscript.ps1\" --stateFieldsDefinitionName \"state-fields.csv\" --withStateFieldsDefinition true", "PowerShell");
+            writer.WriteCodeBlock(
+                "pacx script table --tableName \"custom_mytable\" --customPrefixs \"custom_\" --output \"C:/output\" --scriptFileName \"myscript.ps1\" --stateFileName \"state-fields.csv\" --includeStateFields",
+                "PowerShell");
         }
     }
 }


### PR DESCRIPTION
Renamed parameters in command examples across
ScriptAllCommand.cs, ScriptSolutionCommand.cs, and ScriptTableCommand.cs. Changed `--pacxScriptName` to `--scriptFileName`, `--stateFieldsDefinitionName` to `--stateFileName`, and updated `--withStateFieldsDefinition` to `--includeStateFields` for improved clarity and usability.