### PR TITLE
feat: Integrate publisherBlacklist parameter

### DIFF
--- a/Greg.Xrm.Command.Core.TestSuite/Commands/Solution/GetPublisherListCommandExecutorUnitTests.cs
+++ b/Greg.Xrm.Command.Core.TestSuite/Commands/Solution/GetPublisherListCommandExecutorUnitTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+
+namespace Greg.Xrm.Command.Commands.Solution
+{
+	[TestClass]
+	public class GetPublisherListCommandExecutorUnitTests : CommandExecutorTestBase
+	{
+		private readonly GetPublisherListCommandExecutor executor;
+
+		public GetPublisherListCommandExecutorUnitTests()
+		{
+			this.executor = new GetPublisherListCommandExecutor(this.Output, this.OrganizationServiceRepositoryMock.Object);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_WithDefaultBlacklist_ShouldQueryWithDefaults()
+		{
+			this.OrganizationServiceMock
+				.Setup(x => x.RetrieveMultipleAsync(It.IsAny<QueryExpression>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(new EntityCollection());
+
+			var command = new GetPublisherListCommand();
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess);
+
+			this.OrganizationServiceMock.Verify(x => x.RetrieveMultipleAsync(It.Is<QueryExpression>(q => 
+				q.EntityName == "publisher" &&
+				q.Criteria.Conditions.Any(c => 
+					c.AttributeName == "uniquename" && 
+					c.Operator == ConditionOperator.NotIn && 
+					((object[])c.Values).Contains("MicrosoftCorporation") &&
+					((object[])c.Values).Contains("microsoftfirstparty")
+				)
+			), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_WithCustomBlacklist_ShouldQueryWithCustomValues()
+		{
+			this.OrganizationServiceMock
+				.Setup(x => x.RetrieveMultipleAsync(It.IsAny<QueryExpression>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(new EntityCollection());
+
+			var command = new GetPublisherListCommand { publisherBlacklist = "Custom1,Custom2" };
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess);
+
+			this.OrganizationServiceMock.Verify(x => x.RetrieveMultipleAsync(It.Is<QueryExpression>(q => 
+				q.EntityName == "publisher" &&
+				q.Criteria.Conditions.Any(c => 
+					c.AttributeName == "uniquename" && 
+					c.Operator == ConditionOperator.NotIn && 
+					((object[])c.Values).Contains("Custom1") &&
+					((object[])c.Values).Contains("Custom2")
+				)
+			), It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_WithEmptyBlacklist_ShouldQueryWithoutBlacklistCondition()
+		{
+			this.OrganizationServiceMock
+				.Setup(x => x.RetrieveMultipleAsync(It.IsAny<QueryExpression>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(new EntityCollection());
+
+			var command = new GetPublisherListCommand { publisherBlacklist = "" };
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess);
+
+			this.OrganizationServiceMock.Verify(x => x.RetrieveMultipleAsync(It.Is<QueryExpression>(q => 
+				q.EntityName == "publisher" &&
+				!q.Criteria.Conditions.Any(c => c.AttributeName == "uniquename" && c.Operator == ConditionOperator.NotIn)
+			), It.IsAny<CancellationToken>()), Times.Once);
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Solution/GetPublisherListCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Solution/GetPublisherListCommandExecutor.cs
@@ -2,10 +2,6 @@ using Greg.Xrm.Command.Services.Connection;
 using Greg.Xrm.Command.Services.Output;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Greg.Xrm.Command.Commands.Solution
 {
@@ -23,12 +19,12 @@ namespace Greg.Xrm.Command.Commands.Solution
 
 				string[] blackListPublisher = { "MicrosoftCorporation", "microsoftfirstparty" };
 
-				if (!string.IsNullOrEmpty(command.publisherBlacklist))
+				if(!string.IsNullOrEmpty(command.publisherBlacklist))
 					blackListPublisher = command.publisherBlacklist.Split(',', StringSplitOptions.TrimEntries);
 
 				var query = new QueryExpression("publisher");
 				query.NoLock = true;
-
+				
 				query.ColumnSet.AddColumns(
 					"friendlyname",
 					"customizationprefix",
@@ -42,8 +38,8 @@ namespace Greg.Xrm.Command.Commands.Solution
 
 				if (blackListPublisher.Length > 0)
 					query.Criteria.AddCondition("uniquename", ConditionOperator.NotIn, blackListPublisher);
-
-				var listPublisher = (await crm.RetrieveMultipleAsync(query)).Entities;
+				
+				var listPublisher = (await crm.RetrieveMultipleAsync(query, cancellationToken)).Entities;
 
 
 				output.WriteTable(listPublisher,
@@ -68,7 +64,7 @@ namespace Greg.Xrm.Command.Commands.Solution
 
 		}
 
-		private static Func<string[]> publisherListColumns(bool verbose)
+		private Func<string[]> publisherListColumns(bool verbose)
 		{
 			string[] columns = {
 				"Unique name",
@@ -88,7 +84,7 @@ namespace Greg.Xrm.Command.Commands.Solution
 
 			return () => columns;
 		}
-		private static Func<Entity, string[]> publisherListData(bool verbose)
+		private Func<Entity, string[]> publisherListData(bool verbose)
 		{
 			return (user) =>
 			{
@@ -104,7 +100,7 @@ namespace Greg.Xrm.Command.Commands.Solution
 						user.GetFormattedValue("customizationoptionvalueprefix") ?? string.Empty,
 						user.GetAttributeValue<DateTime?>("createdon").GetValueOrDefault().ToLocalTime().ToString() ?? string.Empty,
 						user.GetFormattedValue("createdby") ?? string.Empty,
-						user.GetAttributeValue<string>("description") ?? string.Empty
+						user.GetAttributeValue<string>("description") ?? string.Empty						
 					}).ToArray();
 				}
 


### PR DESCRIPTION
Closes #180

## Overview
Integrate \publisherBlacklist\ parameter for \solution get-publisher-list\ command from upstream branch \ixPublisherBlacklist\.

## Changes
- Added \publisherBlacklist\ option to \GetPublisherListCommand\.
- Updated \GetPublisherListCommandExecutor\ to use the blacklist parameter.
- Added unit tests to verify filtering logic.