### PR TITLE
Add EntitySetName support to constants generation

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Solution/Model/EntityMetadataManager.cs
+++ b/Greg.Xrm.Command.Core/Commands/Solution/Model/EntityMetadataManager.cs
@@ -7,12 +7,14 @@ namespace Greg.Xrm.Command.Commands.Solution.Model
 		public EntityMetadataManager(
 			string entityDisplayName,
 			string entityLogicalName,
+			string entitySetName,
 			bool isActivity,
 			List<string> commonFields)
 		{
 			EntityDisplayName = entityDisplayName;
 			EntityDisplayNameWithoutSpecialChar = entityDisplayName.Replace(" ", string.Empty).RemoveSpecialCharacters();
 			EntityLogicalName = entityLogicalName;
+			EntitySetName = entitySetName;
 			IsActivity = isActivity;
 			Attributes = new List<AttributeMetadataManager>();
 			OptionSetAttributes = new List<AttributeMetadataManagerForPicklist>();
@@ -22,6 +24,7 @@ namespace Greg.Xrm.Command.Commands.Solution.Model
 		public string EntityDisplayName { get; }
 		public string EntityDisplayNameWithoutSpecialChar { get; }
 		public string EntityLogicalName { get; }
+		public string EntitySetName { get; }
 		public bool IsActivity { get; }
 		public List<AttributeMetadataManagerForPicklist> OptionSetAttributes { get; set; }
 		public AttributeMetadataManagerForStatus? StatusAttribute { get; set; }

--- a/Greg.Xrm.Command.Core/Commands/Solution/Service/ConstantsGeneratorService.cs
+++ b/Greg.Xrm.Command.Core/Commands/Solution/Service/ConstantsGeneratorService.cs
@@ -90,7 +90,7 @@ namespace Greg.Xrm.Command.Commands.Solution.Service
 
 				var label = entMetadata.DisplayName.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
 				output.WriteLine($"    {label}", ConsoleColor.Gray);
-				var entityManager = new EntityMetadataManager(label, entMetadata.LogicalName, entMetadata.IsActivity == true, EntityCommonFields.ToList());
+				var entityManager = new EntityMetadataManager(label, entMetadata.LogicalName, entMetadata.EntitySetName ?? string.Empty, entMetadata.IsActivity == true, EntityCommonFields.ToList());
 
 				foreach (var attribute in entMetadata.Attributes)
 				{
@@ -117,8 +117,8 @@ namespace Greg.Xrm.Command.Commands.Solution.Service
 					.Where(a => EntityCommonFields.Contains(a.LogicalName))
 					.ToList();
 
-				entityCommonAttributes = new EntityMetadataManager("Entity Generic", "EntityGenericConstants", false, new List<string>());
-				foreach (var attr in commonAttrList)
+				entityCommonAttributes = new EntityMetadataManager("Entity Generic", "EntityGenericConstants", string.Empty, false, new List<string>());
+					foreach (var attr in commonAttrList)
 				{
 					if (attr.DisplayName.LocalizedLabels.Count <= 0)
 						continue;
@@ -127,7 +127,7 @@ namespace Greg.Xrm.Command.Commands.Solution.Service
 			}
 			else
 			{
-				entityCommonAttributes = new EntityMetadataManager("Entity Generic", "EntityGenericConstants", false, new List<string>());
+				entityCommonAttributes = new EntityMetadataManager("Entity Generic", "EntityGenericConstants", string.Empty, false, new List<string>());
 			}
 			entityData.Insert(0, entityCommonAttributes);
 

--- a/Greg.Xrm.Command.Core/Commands/Solution/Writers/WriteConstantsToFileCs.cs
+++ b/Greg.Xrm.Command.Core/Commands/Solution/Writers/WriteConstantsToFileCs.cs
@@ -125,6 +125,10 @@ namespace Greg.Xrm.Command.Commands.Solution.Writers
 			WriteLine("\t\t/// " + entityConstants.EntityDisplayName);
 			WriteLine("\t\t/// </summary>");
 			WriteLine("\t\tpublic static string displayName => \"" + entityConstants.EntityDisplayName + "\";" + Environment.NewLine);
+			WriteLine("\t\t/// <summary>");
+			WriteLine("\t\t/// " + entityConstants.EntitySetName);
+			WriteLine("\t\t/// </summary>");
+			WriteLine("\t\tpublic static string entitySetName => \"" + entityConstants.EntitySetName + "\";" + Environment.NewLine);
 		}
 
 		public override void WriteAttributes(EntityMetadataManager manager, string lastAttribute)

--- a/Greg.Xrm.Command.Core/Commands/Solution/Writers/WriteConstantsToFileJs.cs
+++ b/Greg.Xrm.Command.Core/Commands/Solution/Writers/WriteConstantsToFileJs.cs
@@ -66,8 +66,9 @@ namespace Greg.Xrm.Command.Commands.Solution.Writers
 			WriteLine(Environment.NewLine + NameSpaceJsName + "." + entityConstants.EntityLogicalName + " = {");
 			WriteLine("\t///" + entityConstants.EntityDisplayName + " constants.");
 			if (entityConstants.EntityLogicalName == "EntityGenericConstants") return;
-			WriteLine("\tlogicalName: \"" + entityConstants.EntityLogicalName + "\",");
-			WriteLine("\tdisplayName: \"" + entityConstants.EntityDisplayName + "\",");
+				WriteLine("\tlogicalName: \"" + entityConstants.EntityLogicalName + "\",");
+				WriteLine("\tdisplayName: \"" + entityConstants.EntityDisplayName + "\",");
+				WriteLine("\tentitySetName: \"" + entityConstants.EntitySetName + "\",");
 		}
 
 		public override void WriteAttributes(EntityMetadataManager entityConstants, string lastAttribute)


### PR DESCRIPTION
Add EntitySetName support to constants generation

Enhances EntityMetadataManager and constants writers to handle and output the EntitySetName property for entities. Updates ConstantsGeneratorService to pass EntitySetName from metadata, and ensures generic entity constants use an empty string for this value. Generated C# and JS files now include entitySetName.