### PR TITLE
test: Add unit tests for ribbon command group

### DIFF
--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandExecutorTest.cs
@@ -134,12 +134,23 @@ namespace Greg.Xrm.Command.Commands.Ribbon
 		public async Task ExecuteAsync_ShouldFail_WhenOutputFolderDoesNotExist()
 		{
 			SetupEntityRibbonResponse(CreateRibbonZip(RibbonXml));
-			var fileName = Path.Combine(Path.GetTempPath(), "PACX-does-not-exist-" + Guid.NewGuid(), "ribbon.xml");
+			var folder = Path.Combine(Path.GetTempPath(), "PACX-does-not-exist-" + Guid.NewGuid());
+			var fileName = Path.Combine(folder, "ribbon.xml");
 			var command = new GetRibbonCommand { EntityName = "account", FileName = fileName };
 
-			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+			try
+			{
+				var result = await executor.ExecuteAsync(command, CancellationToken.None);
 
-			Assert.IsFalse(result.IsSuccess);
+				Assert.IsFalse(result.IsSuccess);
+			}
+			finally
+			{
+				if (Directory.Exists(folder))
+				{
+					Directory.Delete(folder, true);
+				}
+			}
 		}
 
 		// ── error handling ────────────────────────────────────────────────────

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandExecutorTest.cs
@@ -1,0 +1,173 @@
+using System.IO.Packaging;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Ribbon
+{
+	[TestClass]
+	public class GetRibbonCommandExecutorTest : CommandExecutorTestBase
+	{
+		private const string RibbonXml = "<RibbonDefinitions><RibbonDefinition><UI /></RibbonDefinition></RibbonDefinitions>";
+
+		private readonly GetRibbonCommandExecutor executor;
+		private OrganizationRequest? capturedRequest;
+
+		public GetRibbonCommandExecutorTest()
+		{
+			this.executor = new GetRibbonCommandExecutor(
+				this.Output,
+				this.OrganizationServiceRepositoryMock.Object);
+		}
+
+		// ── helpers ───────────────────────────────────────────────────────────
+
+		/// <summary>
+		/// Builds the same payload Dataverse returns: a zip package containing
+		/// a single /RibbonXml.xml part (see GetRibbonCommandExecutor.UnzipRibbonXml).
+		/// </summary>
+		private static byte[] CreateRibbonZip(string xml)
+		{
+			using var stream = new MemoryStream();
+			using (var package = Package.Open(stream, FileMode.Create))
+			{
+				var part = package.CreatePart(new Uri("/RibbonXml.xml", UriKind.Relative), "text/xml");
+				using var partStream = part.GetStream();
+				var bytes = Encoding.UTF8.GetBytes(xml);
+				partStream.Write(bytes, 0, bytes.Length);
+			}
+			return stream.ToArray();
+		}
+
+		private void SetupEntityRibbonResponse(byte[] payload)
+		{
+			var response = new RetrieveEntityRibbonResponse();
+			response.Results["CompressedEntityXml"] = payload;
+
+			this.OrganizationServiceMock
+				.Setup(s => s.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+				.Callback<OrganizationRequest>(r => this.capturedRequest = r)
+				.ReturnsAsync(response);
+		}
+
+		private void SetupApplicationRibbonResponse(byte[] payload)
+		{
+			var response = new RetrieveApplicationRibbonResponse();
+			response.Results["CompressedApplicationRibbonXml"] = payload;
+
+			this.OrganizationServiceMock
+				.Setup(s => s.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+				.Callback<OrganizationRequest>(r => this.capturedRequest = r)
+				.ReturnsAsync(response);
+		}
+
+		// ── entity ribbon ─────────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldRequestEntityRibbon_WhenTableIsSpecified()
+		{
+			SetupEntityRibbonResponse(CreateRibbonZip(RibbonXml));
+			var command = new GetRibbonCommand { EntityName = "account" };
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			var request = this.capturedRequest as RetrieveEntityRibbonRequest;
+			Assert.IsNotNull(request, "Executor should send a RetrieveEntityRibbonRequest when --table is set");
+			Assert.AreEqual("account", request.EntityName);
+			Assert.AreEqual(RibbonLocationFilters.All, request.RibbonLocationFilter);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldWriteRibbonXmlToOutput()
+		{
+			SetupEntityRibbonResponse(CreateRibbonZip(RibbonXml));
+			var command = new GetRibbonCommand { EntityName = "account" };
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), RibbonXml);
+		}
+
+		// ── application ribbon ────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldRequestApplicationRibbon_WhenTableIsOmitted()
+		{
+			SetupApplicationRibbonResponse(CreateRibbonZip(RibbonXml));
+			var command = new GetRibbonCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			Assert.IsInstanceOfType(this.capturedRequest, typeof(RetrieveApplicationRibbonRequest),
+				"Executor should fall back to the application ribbon when no --table is given");
+		}
+
+		// ── file output ───────────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldSaveRibbonToFile_WhenOutputIsSpecified()
+		{
+			// AutoRun deliberately stays false: a unit test must not spawn a process.
+			SetupEntityRibbonResponse(CreateRibbonZip(RibbonXml));
+			var folder = Utility.CreateTempFolder();
+			try
+			{
+				var fileName = Path.Combine(folder, "ribbon.xml");
+				var command = new GetRibbonCommand { EntityName = "account", FileName = fileName };
+
+				var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+				Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+				Assert.IsTrue(File.Exists(fileName), "Ribbon file should have been created");
+				Assert.AreEqual(RibbonXml, File.ReadAllText(fileName));
+			}
+			finally
+			{
+				Utility.DeleteFolder(folder);
+			}
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenOutputFolderDoesNotExist()
+		{
+			SetupEntityRibbonResponse(CreateRibbonZip(RibbonXml));
+			var fileName = Path.Combine(Path.GetTempPath(), "PACX-does-not-exist-" + Guid.NewGuid(), "ribbon.xml");
+			var command = new GetRibbonCommand { EntityName = "account", FileName = fileName };
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+		}
+
+		// ── error handling ────────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenDataverseCallThrows()
+		{
+			this.OrganizationServiceMock
+				.Setup(s => s.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+				.ThrowsAsync(new InvalidOperationException("Entity with name 'foo' does not exist"));
+
+			var command = new GetRibbonCommand { EntityName = "foo" };
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not exist");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenPayloadIsNotAValidZip()
+		{
+			SetupEntityRibbonResponse([1, 2, 3, 4]);
+			var command = new GetRibbonCommand { EntityName = "account" };
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Ribbon/GetRibbonCommandTest.cs
@@ -1,0 +1,113 @@
+namespace Greg.Xrm.Command.Commands.Ribbon
+{
+	[TestClass]
+	public class GetRibbonCommandTest
+	{
+		// ── no options — valid because everything is optional ─────────────────
+
+		[TestMethod]
+		public void ParseWithNoOptionsShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get");
+
+			Assert.AreEqual(string.Empty, command.EntityName);
+			Assert.AreEqual(string.Empty, command.FileName);
+			Assert.IsFalse(command.AutoRun);
+		}
+
+		// ── --table / -t ──────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void TableOptionWithLongNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"--table", "account");
+
+			Assert.AreEqual("account", command.EntityName);
+		}
+
+		[TestMethod]
+		public void TableOptionWithShortNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"-t", "account");
+
+			Assert.AreEqual("account", command.EntityName);
+		}
+
+		// ── --output / -o ─────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void OutputOptionWithLongNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"--output", "ribbon.xml");
+
+			Assert.AreEqual("ribbon.xml", command.FileName);
+		}
+
+		[TestMethod]
+		public void OutputOptionWithShortNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"-o", @"C:\temp\ribbon.xml");
+
+			Assert.AreEqual(@"C:\temp\ribbon.xml", command.FileName);
+		}
+
+		// ── --autorun / -r ────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void AutoRunShouldDefaultToFalse()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"--table", "account");
+
+			Assert.IsFalse(command.AutoRun);
+		}
+
+		[TestMethod]
+		public void AutoRunWithLongNameShouldBeTrueWhenProvided()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"--table", "account",
+				"--autorun");
+
+			Assert.IsTrue(command.AutoRun);
+		}
+
+		[TestMethod]
+		public void AutoRunWithShortNameShouldBeTrueWhenProvided()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"-t", "account",
+				"-r");
+
+			Assert.IsTrue(command.AutoRun);
+		}
+
+		// ── combined ──────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void AllOptionsTogetherShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetRibbonCommand>(
+				"ribbon", "get",
+				"-t", "account",
+				"-o", "ribbon.xml",
+				"-r");
+
+			Assert.AreEqual("account", command.EntityName);
+			Assert.AreEqual("ribbon.xml", command.FileName);
+			Assert.IsTrue(command.AutoRun);
+		}
+	}
+}


### PR DESCRIPTION
Hi Riccardo, first of all thanks for PACX — it has become a core part of my
daily workflow at work, and honestly saves me a ridiculous amount of time.

While reading the source I noticed the `ribbon` command group has no test
coverage yet. This PR adds 16 unit tests for it, following the two patterns
documented in `.github/copilot-instructions.md` (and the precedent of #150):

**`GetRibbonCommandTest`** — parser tests:
- `--table` / `-t`, `--output` / `-o`, `--autorun` / `-r` (long + short names)
- defaults when options are omitted, combined usage

**`GetRibbonCommandExecutorTest`** — executor tests (Moq via `CommandExecutorTestBase`):
- sends `RetrieveEntityRibbonRequest` with `RibbonLocationFilters.All` when `--table` is set
- falls back to `RetrieveApplicationRibbonRequest` when it is not
- writes the ribbon XML to output and (when `--output` is set) to file
- error handling: failed Dataverse call, invalid zip payload, invalid output path

The Dataverse response is simulated with an in-memory zip containing a
`/RibbonXml.xml` part, mirroring what `RetrieveEntityRibbon` /
`RetrieveApplicationRibbon` actually return — built with the same
`System.IO.Packaging` API the executor uses to unzip, so the round-trip
matches production behavior.

`AutoRun = true` is deliberately left untested, since it would spawn a
process from within a unit test.

Full suite passes locally: **307/307**.

Happy to adjust naming, structure or anything else to your taste.