### PR TITLE
Add 'pacx plugin trace list' to read plugin trace logs from the CLI

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Plugin/Trace/Help.cs
+++ b/Greg.Xrm.Command.Core/Commands/Plugin/Trace/Help.cs
@@ -1,0 +1,11 @@
+using Greg.Xrm.Command.Parsing;
+
+namespace Greg.Xrm.Command.Commands.Plugin.Trace
+{
+	public class Help : NamespaceHelperBase
+	{
+		public Help() : base("Read plugin trace logs", "plugin", "trace")
+		{
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Plugin/Trace/ListCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Plugin/Trace/ListCommand.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+
+namespace Greg.Xrm.Command.Commands.Plugin.Trace
+{
+	[Command("plugin", "trace", "list",
+		HelpText = "Lists the most recent plugin trace log records, newest first.")]
+	public class ListCommand : IValidatableObject, ICanProvideUsageExample
+	{
+		[Option("name", "n", Order = 1,
+			HelpText = "Case-insensitive substring match against the plugin type name.")]
+		public string? TypeName { get; set; }
+
+		[Option("top", "t", Order = 2,
+			HelpText = "Number of trace log records to show (newest first).",
+			DefaultValue = 10)]
+		public int Top { get; set; } = 10;
+
+		[Option("errors-only", "e", Order = 3,
+			HelpText = "Shows only trace log records that contain exception details.",
+			DefaultValue = false)]
+		public bool ErrorsOnly { get; set; } = false;
+
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			if (Top <= 0 || Top > 1000)
+			{
+				yield return new ValidationResult("The --top argument must be between 1 and 1000.", [nameof(Top)]);
+			}
+		}
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("Show the 10 most recent plugin trace log records:");
+			writer.WriteCodeBlock("pacx plugin trace list", "Powershell");
+
+			writer.WriteParagraph("Show the most recent traces of a given plugin (substring match on the type name):");
+			writer.WriteCodeBlock("pacx plugin trace list --name MyPlugin", "Powershell");
+
+			writer.WriteParagraph("Show only failed executions (records containing exception details):");
+			writer.WriteCodeBlock("pacx plugin trace list --errors-only", "Powershell");
+
+			writer.WriteParagraph("Typical debug loop: push a new plugin version, trigger it, then check its traces:");
+			writer.WriteCodeBlock("pacx plugin trace list -n MyPlugin -e -t 5", "Powershell");
+
+			writer.WriteParagraph("Note: trace log records are written only when trace logging is enabled on the environment (organization setting `plugintracelogsetting`), and Dataverse deletes them automatically after 24 hours.");
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Plugin/Trace/ListCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Plugin/Trace/ListCommandExecutor.cs
@@ -1,0 +1,135 @@
+using System.ServiceModel;
+using Greg.Xrm.Command.Services.Connection;
+using Greg.Xrm.Command.Services.Output;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Greg.Xrm.Command.Commands.Plugin.Trace
+{
+	public class ListCommandExecutor(
+		IOutput output,
+		IOrganizationServiceRepository organizationServiceRepository)
+		: ICommandExecutor<ListCommand>
+	{
+		public async Task<CommandResult> ExecuteAsync(ListCommand command, CancellationToken cancellationToken)
+		{
+			output.Write("Connecting to the current dataverse environment...");
+			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			try
+			{
+				output.Write("Retrieving plugin trace logs...");
+
+				var q = new QueryExpression("plugintracelog")
+				{
+					NoLock = true,
+					TopCount = command.Top
+				};
+				q.ColumnSet.AddColumns(
+					"createdon", "typename", "messagename", "primaryentity", "mode", "depth",
+					"performanceexecutionduration", "messageblock", "exceptiondetails");
+
+				if (!string.IsNullOrWhiteSpace(command.TypeName))
+					q.Criteria.AddCondition("typename", ConditionOperator.Like, $"%{command.TypeName}%");
+
+				if (command.ErrorsOnly)
+					q.Criteria.AddCondition("exceptiondetails", ConditionOperator.NotNull);
+
+				q.AddOrder("createdon", OrderType.Descending);
+
+				var results = await crm.RetrieveMultipleAsync(q, cancellationToken);
+				output.WriteLine("Done", ConsoleColor.Green);
+
+				if (results.Entities.Count == 0)
+				{
+					output.WriteLine("No plugin trace log records found matching the specified criteria.", ConsoleColor.Yellow);
+					output.WriteLine("Trace logs are written only when trace logging is enabled on the environment (organization setting 'plugintracelogsetting'), and records are deleted automatically after 24 hours.", ConsoleColor.DarkGray);
+					return CommandResult.Success();
+				}
+
+				output.WriteLine();
+
+				foreach (var row in results.Entities)
+				{
+					WriteTraceRecord(row);
+				}
+
+				var result = CommandResult.Success();
+				result["Count"] = results.Entities.Count;
+				return result;
+			}
+			catch (FaultException<OrganizationServiceFault> ex)
+			{
+				output.WriteLine("Failed", ConsoleColor.Red);
+				return CommandResult.Fail(ex.Message, ex);
+			}
+		}
+
+		private void WriteTraceRecord(Entity row)
+		{
+			var createdOn = row.GetAttributeValue<DateTime?>("createdon");
+			var typeName = row.GetAttributeValue<string>("typename") ?? string.Empty;
+			var messageName = row.GetAttributeValue<string>("messagename") ?? string.Empty;
+			var primaryEntity = row.GetAttributeValue<string>("primaryentity") ?? string.Empty;
+			var mode = row.GetAttributeValue<OptionSetValue>("mode");
+			var depth = row.GetAttributeValue<int?>("depth");
+			var duration = row.GetAttributeValue<int?>("performanceexecutionduration");
+			var messageBlock = row.GetAttributeValue<string>("messageblock");
+			var exceptionDetails = row.GetAttributeValue<string>("exceptiondetails");
+
+			output.Write(createdOn?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "(no date)", ConsoleColor.White);
+			output.Write("  ");
+			output.Write(TypeDisplayName(typeName), ConsoleColor.Cyan);
+			output.WriteLine();
+
+			var operation = string.IsNullOrWhiteSpace(primaryEntity) || primaryEntity == "none"
+				? messageName
+				: $"{messageName} on {primaryEntity}";
+			var version = TypeVersion(typeName);
+			var details = $"  {operation}  [{ModeLabel(mode)}, depth {depth?.ToString() ?? "?"}, {(duration.HasValue ? duration + " ms" : "n/a")}{(version == null ? string.Empty : ", v" + version)}]";
+			output.WriteLine(details, ConsoleColor.DarkGray);
+
+			WriteIndentedBlock(messageBlock, ConsoleColor.Gray);
+			WriteIndentedBlock(exceptionDetails, ConsoleColor.Red);
+
+			output.WriteLine();
+		}
+
+		private void WriteIndentedBlock(string? text, ConsoleColor color)
+		{
+			if (string.IsNullOrWhiteSpace(text)) return;
+
+			foreach (var line in text.Replace("\r\n", "\n").Split('\n'))
+			{
+				output.WriteLine("    " + line, color);
+			}
+		}
+
+		// typename holds the assembly qualified name ("My.Plugin, MyAssembly, Version=1.0.0.0, ...").
+		// Only the class name and the version are relevant when reading traces.
+		private static string TypeDisplayName(string typeName)
+		{
+			var comma = typeName.IndexOf(',');
+			return comma < 0 ? typeName : typeName[..comma].TrimEnd();
+		}
+
+		private static string? TypeVersion(string typeName)
+		{
+			foreach (var part in typeName.Split(','))
+			{
+				var trimmed = part.Trim();
+				if (trimmed.StartsWith("Version=", StringComparison.OrdinalIgnoreCase))
+					return trimmed["Version=".Length..];
+			}
+			return null;
+		}
+
+		private static string ModeLabel(OptionSetValue? mode) => mode?.Value switch
+		{
+			0 => "Sync",
+			1 => "Async",
+			_ => "Unknown"
+		};
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Plugin/Trace/ListCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Plugin/Trace/ListCommandExecutorTest.cs
@@ -1,0 +1,179 @@
+using System.ServiceModel;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Greg.Xrm.Command.Commands.Plugin.Trace
+{
+	[TestClass]
+	public class ListCommandExecutorTest : CommandExecutorTestBase
+	{
+		private readonly ListCommandExecutor executor;
+		private QueryExpression? capturedQuery;
+
+		public ListCommandExecutorTest()
+		{
+			this.executor = new ListCommandExecutor(
+				this.Output,
+				this.OrganizationServiceRepositoryMock.Object);
+		}
+
+		// ── helpers ───────────────────────────────────────────────────────────
+
+		private static Entity CreateTraceRow(
+			string typeName = "MyPlugin.Plugin1",
+			string messageName = "Create",
+			string primaryEntity = "account",
+			string? messageBlock = "step 1 done",
+			string? exceptionDetails = null)
+		{
+			var row = new Entity("plugintracelog", Guid.NewGuid());
+			row["createdon"] = new DateTime(2026, 7, 12, 10, 30, 0, DateTimeKind.Utc);
+			row["typename"] = typeName;
+			row["messagename"] = messageName;
+			row["primaryentity"] = primaryEntity;
+			row["mode"] = new OptionSetValue(0);
+			row["depth"] = 1;
+			row["performanceexecutionduration"] = 42;
+			if (messageBlock != null) row["messageblock"] = messageBlock;
+			if (exceptionDetails != null) row["exceptiondetails"] = exceptionDetails;
+			return row;
+		}
+
+		private void SetupResponse(params Entity[] rows)
+		{
+			this.OrganizationServiceMock
+				.Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()))
+				.Callback<QueryBase, CancellationToken>((qb, _) => this.capturedQuery = qb as QueryExpression)
+				.ReturnsAsync(new EntityCollection(rows.ToList()));
+		}
+
+		// ── query construction ────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldQueryPluginTraceLog_NewestFirst()
+		{
+			SetupResponse(CreateTraceRow());
+			var command = new ListCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			Assert.IsNotNull(this.capturedQuery);
+			Assert.AreEqual("plugintracelog", this.capturedQuery.EntityName);
+			Assert.AreEqual(10, this.capturedQuery.TopCount);
+			Assert.AreEqual(1, this.capturedQuery.Orders.Count);
+			Assert.AreEqual("createdon", this.capturedQuery.Orders[0].AttributeName);
+			Assert.AreEqual(OrderType.Descending, this.capturedQuery.Orders[0].OrderType);
+			Assert.AreEqual(0, this.capturedQuery.Criteria.Conditions.Count);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFilterByTypeName_WhenNameIsSet()
+		{
+			SetupResponse(CreateTraceRow());
+			var command = new ListCommand { TypeName = "MyPlugin" };
+
+			await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsNotNull(this.capturedQuery);
+			var condition = this.capturedQuery.Criteria.Conditions.Single();
+			Assert.AreEqual("typename", condition.AttributeName);
+			Assert.AreEqual(ConditionOperator.Like, condition.Operator);
+			Assert.AreEqual("%MyPlugin%", condition.Values[0]);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFilterByExceptionDetails_WhenErrorsOnlyIsSet()
+		{
+			SetupResponse(CreateTraceRow(exceptionDetails: "boom"));
+			var command = new ListCommand { ErrorsOnly = true };
+
+			await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsNotNull(this.capturedQuery);
+			var condition = this.capturedQuery.Criteria.Conditions.Single();
+			Assert.AreEqual("exceptiondetails", condition.AttributeName);
+			Assert.AreEqual(ConditionOperator.NotNull, condition.Operator);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldRespectTop()
+		{
+			SetupResponse(CreateTraceRow());
+			var command = new ListCommand { Top = 3 };
+
+			await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsNotNull(this.capturedQuery);
+			Assert.AreEqual(3, this.capturedQuery.TopCount);
+		}
+
+		// ── output ────────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldWriteTraceDetailsToOutput()
+		{
+			SetupResponse(CreateTraceRow(
+				typeName: "MyPlugin.AccountNumberPlugin",
+				messageBlock: "generated account number",
+				exceptionDetails: "System.InvalidOperationException: boom"));
+			var command = new ListCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			var text = this.Output.ToString();
+			StringAssert.Contains(text, "MyPlugin.AccountNumberPlugin");
+			StringAssert.Contains(text, "generated account number");
+			StringAssert.Contains(text, "System.InvalidOperationException: boom");
+			Assert.AreEqual(1, result["Count"]);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldShowClassNameAndVersion_WhenTypeNameIsAssemblyQualified()
+		{
+			SetupResponse(CreateTraceRow(
+				typeName: "MyPlugin.AccountNumberPlugin, MyPlugin, Version=1.2.0.0, Culture=neutral, PublicKeyToken=abcdef1234567890"));
+			var command = new ListCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			var text = this.Output.ToString();
+			StringAssert.Contains(text, "MyPlugin.AccountNumberPlugin");
+			StringAssert.Contains(text, "v1.2.0.0");
+			Assert.IsFalse(text.Contains("PublicKeyToken"), "The assembly qualified name should not be printed as-is.");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldSucceedWithHint_WhenNoRecordsFound()
+		{
+			SetupResponse();
+			var command = new ListCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "No plugin trace log records found");
+		}
+
+		// ── error handling ────────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenDataverseCallFaults()
+		{
+			this.OrganizationServiceMock
+				.Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new FaultException<OrganizationServiceFault>(
+					new OrganizationServiceFault { Message = "The 'RetrieveMultiple' method does not support entities of type 'plugintracelog'." },
+					new FaultReason("The 'RetrieveMultiple' method does not support entities of type 'plugintracelog'.")));
+
+			var command = new ListCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not support");
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Plugin/Trace/ListCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Plugin/Trace/ListCommandTest.cs
@@ -1,0 +1,143 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.Plugin.Trace
+{
+	[TestClass]
+	public class ListCommandTest
+	{
+		// ── no options — valid because everything is optional ─────────────────
+
+		[TestMethod]
+		public void ParseWithNoOptionsShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list");
+
+			Assert.IsNull(command.TypeName);
+			Assert.AreEqual(10, command.Top);
+			Assert.IsFalse(command.ErrorsOnly);
+		}
+
+		// ── --name / -n ───────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void NameOptionWithLongNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"--name", "MyPlugin");
+
+			Assert.AreEqual("MyPlugin", command.TypeName);
+		}
+
+		[TestMethod]
+		public void NameOptionWithShortNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"-n", "MyPlugin.Plugin1");
+
+			Assert.AreEqual("MyPlugin.Plugin1", command.TypeName);
+		}
+
+		// ── --top / -t ────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void TopShouldDefaultTo10()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list");
+
+			Assert.AreEqual(10, command.Top);
+		}
+
+		[TestMethod]
+		public void TopOptionWithLongNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"--top", "25");
+
+			Assert.AreEqual(25, command.Top);
+		}
+
+		[TestMethod]
+		public void TopOptionWithShortNameShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"-t", "5");
+
+			Assert.AreEqual(5, command.Top);
+		}
+
+		// ── --errors-only / -e ────────────────────────────────────────────────
+
+		[TestMethod]
+		public void ErrorsOnlyShouldDefaultToFalse()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list");
+
+			Assert.IsFalse(command.ErrorsOnly);
+		}
+
+		[TestMethod]
+		public void ErrorsOnlyWithLongNameShouldBeTrueWhenProvided()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"--errors-only");
+
+			Assert.IsTrue(command.ErrorsOnly);
+		}
+
+		[TestMethod]
+		public void ErrorsOnlyWithShortNameShouldBeTrueWhenProvided()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"-e");
+
+			Assert.IsTrue(command.ErrorsOnly);
+		}
+
+		// ── combined ──────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void AllOptionsTogetherShouldWork()
+		{
+			var command = Utility.TestParseCommand<ListCommand>(
+				"plugin", "trace", "list",
+				"-n", "MyPlugin",
+				"-t", "5",
+				"-e");
+
+			Assert.AreEqual("MyPlugin", command.TypeName);
+			Assert.AreEqual(5, command.Top);
+			Assert.IsTrue(command.ErrorsOnly);
+		}
+
+		// ── validation ────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void ValidateShouldFailWhenTopIsZeroOrNegative()
+		{
+			var command = new ListCommand { Top = 0 };
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldPassForDefaultValues()
+		{
+			var command = new ListCommand();
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+	}
+}


### PR DESCRIPTION
I asked about this in #205 a while ago and went ahead and built it. If it doesn't fit the tool, no problem, feel free to close this.

This adds a plugin trace command group with a single list command that reads the most recent plugintracelog records, newest first. You can filter by plugin type name with `--name` (substring match), limit the number of records with `--top` (default 10) and show only failed executions with `--errors-only`. Each record is printed with timestamp, plugin class name, message, entity, mode, depth, duration and assembly version. Below that the trace message block is printed indented, and exception details in red if there are any. When nothing is found the command prints a hint about the plugintracelogsetting organization setting and the 24 hour retention, since in my experience that is usually the reason for an empty result.

Example output:

```
2026-07-31 20:48:17  MyPlugin.AccountNumberPlugin
  Create on account  [Sync, depth 1, 62 ms, v1.0.0.0]
    [+276ms] - [Execute] - Entered MyPlugin.AccountNumberPlugin.Execute() Correlation Id:
b4a81f52-6c1d-4e0a-9f3b-2d7c8a5e1b90, Initiating User: 3f6e2a18-90cd-4b7a-8e51-c40d9b26a7f3
    [+0ms] - AccountNumberPlugin: started
    [+0ms] - AccountNumberPlugin: Message=Create, Entity=account, Stage=20, Depth=1
    [+18ms] - AccountNumberPlugin: accountnumber set to 'ACC-2026-00042'
    [+0ms] - AccountNumberPlugin: completed successfully
    [+0ms] - [Execute] - Exiting MyPlugin.AccountNumberPlugin.Execute()
```

There are 20 unit tests for the parser, validation and executor, and the full suite passes locally on current master with the .NET 10 SDK, 659/659. I also tested it against a live environment, the name filter and the ordering work as expected there too.

Happy to adjust namings, output format or anything else :). 