### PR TITLE
Fix stray quote in the interactive option prompt

### DIFF
--- a/Greg.Xrm.Command/Interactive/CommandRunnerInteractive.cs
+++ b/Greg.Xrm.Command/Interactive/CommandRunnerInteractive.cs
@@ -102,7 +102,7 @@ namespace Greg.Xrm.Command.Interactive
 			var dict = new Dictionary<string, string>();
 			foreach (var option in options)
 			{
-				var promptText = $"[{DefaultColors.Primary}]?[/] Provide value for [{DefaultColors.Accent}]--{option.Option.LongName}[/]\"";
+				var promptText = $"[{DefaultColors.Primary}]?[/] Provide value for [{DefaultColors.Accent}]--{option.Option.LongName}[/]";
 				if (option.IsRequired)
 				{
 					promptText += " [red](required)[/]";


### PR DESCRIPTION
The prompt for command options in interactive mode rendered as 'Provide value for --name":' for every option of every command. The trailing escaped quote was left over from an earlier version of the prompt that wrapped the option name in quotes. It looked like this beforehand: 
<img width="229" height="156" alt="image" src="https://github.com/user-attachments/assets/52a599ce-a51e-4fd2-9232-532bd5a3b166" />
Now it looks like this:
<img width="335" height="190" alt="image" src="https://github.com/user-attachments/assets/1efdbe18-1d41-47ff-add9-139de973b8b7" />
