### PR TITLE
Add 'pacx forms addhandler' to register form event handlers from the CLI

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommand.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[Command("forms", "addhandler", HelpText = "Registers a javascript event handler on the main form of a given table")]
+	[Alias("form", "addhandler")]
+	public class AddHandlerCommand : IValidatableObject, ICanProvideUsageExample
+	{
+		[Option("table", "t", Order = 1, HelpText = "The name of the table to which the form belongs")]
+		[Required]
+		public string TableName { get; set; } = string.Empty;
+
+		[Option("library", "l", Order = 2, HelpText = "The name of the javascript webresource that contains the handler function (e.g. myprefix_/scripts/account.js)")]
+		[Required]
+		public string Library { get; set; } = string.Empty;
+
+		[Option("function", "fn", Order = 3, HelpText = "The name of the function to call, including its namespace (e.g. My.Account.onLoad)")]
+		[Required]
+		public string Function { get; set; } = string.Empty;
+
+		[Option("event", "e", Order = 4, HelpText = "The form event to attach the handler to.", DefaultValue = FormEvent.OnLoad)]
+		public FormEvent Event { get; set; } = FormEvent.OnLoad;
+
+		[Option("field", "col", Order = 5, HelpText = "The logical name of the column to watch. Required for (and only valid with) the OnChange event.")]
+		public string? Field { get; set; }
+
+		[Option("passContext", "ctx", Order = 6, HelpText = "Whether the execution context is passed as first parameter to the handler.", DefaultValue = true)]
+		public bool PassExecutionContext { get; set; } = true;
+
+		[Option("form", "f", Order = 7, HelpText = "The name of the form to update. It is required only if the table has more than one Main form.")]
+		public string FormName { get; set; } = string.Empty;
+
+		[Option("solution", "s", Order = 8, HelpText = "The name of the solution that contains the table. If not provided, the default solution will be used")]
+		public string? SolutionName { get; set; }
+
+		[Option("output", "out", Order = 9, HelpText = "If specified, the command will export the original version of the form in the specified folder before applying any change. The folder must exist.")]
+		public string? TempDir { get; set; }
+
+		[Option("fast", "ft", Order = 10, HelpText = "Updates the formxml of the form directly instead of going through a temporary solution. Much faster; the platform still validates the formxml on update, but the all-or-nothing safety of a solution import is skipped.", DefaultValue = false)]
+		public bool Fast { get; set; } = false;
+
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			if (Event == FormEvent.OnChange && string.IsNullOrWhiteSpace(Field))
+			{
+				yield return new ValidationResult("The --field argument is required for the OnChange event.", [nameof(Field)]);
+			}
+
+			if (Event != FormEvent.OnChange && !string.IsNullOrWhiteSpace(Field))
+			{
+				yield return new ValidationResult("The --field argument can only be used with the OnChange event.", [nameof(Field)]);
+			}
+		}
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("Registering event handlers via the form designer is a manual, per-form activity. This command writes the same formLibraries and events entries into the form definition that the designer would, so the registration stays visible (and editable) in the designer afterwards.");
+
+			writer.WriteParagraph("Attach an OnLoad handler to the main form of a table:");
+			writer.WriteCodeBlock("pacx forms addhandler --table account --library myprefix_scripts.js --function My.Account.onLoad", "Powershell");
+
+			writer.WriteParagraph("Attach an OnChange handler to a specific column:");
+			writer.WriteCodeBlock("pacx forms addhandler -t account -l myprefix_scripts.js -fn My.Account.onNameChange -e OnChange --field name", "Powershell");
+
+			writer.WriteParagraph("If the webresource library is not yet referenced by the form, it is added automatically. If the same function of the same library is already registered on the event, the command makes no change, so it is safe to run repeatedly (e.g. from a setup script).");
+
+			writer.WriteParagraph("Use --output to save a backup of the original form before any change is applied, e.g. when running against forms you care about:");
+			writer.WriteCodeBlock("pacx forms addhandler -t account -l myprefix_scripts.js -fn My.Account.onLoad --output C:\\temp", "Powershell");
+
+			writer.WriteParagraph("By default the form is updated through a temporary solution, so the change goes through the all-or-nothing validation of a solution import. Use --fast to update the formxml of the form directly instead, which takes seconds instead of minutes:");
+			writer.WriteCodeBlock("pacx forms addhandler -t account -l myprefix_scripts.js -fn My.Account.onLoad --fast", "Powershell");
+
+			writer.WriteParagraph("Please note: to update the form the command needs to create a temporary solution in the target environment. The temporary solution is deleted automatically once the operation is complete.");
+		}
+	}
+
+	public enum FormEvent
+	{
+		OnLoad,
+		OnSave,
+		OnChange
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommand.cs
@@ -64,7 +64,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 			writer.WriteParagraph("Attach an OnChange handler to a specific column:");
 			writer.WriteCodeBlock("pacx forms addhandler -t account -l myprefix_scripts.js -fn My.Account.onNameChange -e OnChange --field name", "Powershell");
 
-			writer.WriteParagraph("If the webresource library is not yet referenced by the form, it is added automatically. If the same function of the same library is already registered on the event, the command makes no change, so it is safe to run repeatedly (e.g. from a setup script).");
+			writer.WriteParagraph("If the webresource library is not yet referenced by the form, it is added automatically. If the same function of the same library is already registered on the event, the command makes no change (only the passExecutionContext setting is updated when it differs), so it is safe to run repeatedly (e.g. from a setup script).");
 
 			writer.WriteParagraph("Use --output to save a backup of the original form before any change is applied, e.g. when running against forms you care about:");
 			writer.WriteCodeBlock("pacx forms addhandler -t account -l myprefix_scripts.js -fn My.Account.onLoad --output C:\\temp", "Powershell");

--- a/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommandExecutor.cs
@@ -1,0 +1,253 @@
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Greg.Xrm.Command.Commands.Forms.Model;
+using Greg.Xrm.Command.Model;
+using Greg.Xrm.Command.Services.Connection;
+using Greg.Xrm.Command.Services.Output;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	public class AddHandlerCommandExecutor
+	(
+			IOrganizationServiceRepository organizationServiceRepository,
+			IOutput output,
+			IFormRepository formRepository,
+			ISolutionRepository solutionRepository) : ICommandExecutor<AddHandlerCommand>
+	{
+		public async Task<CommandResult> ExecuteAsync(AddHandlerCommand command, CancellationToken cancellationToken)
+		{
+			output.Write($"Connecting to the current dataverse environment...");
+			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			if (!await CheckWebResourceExistsAsync(crm, command.Library))
+			{
+				return CommandResult.Fail($"Webresource <{command.Library}> not found in the current environment. The name must match exactly, check it via 'pacx webresources list' or in the maker portal.");
+			}
+
+			output.Write($"Retrieving main form of table {command.TableName}...");
+			var formList = await formRepository.GetMainFormByTableNameAsync(crm, command.TableName);
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			if (!TryGetForm(command.TableName, command.FormName, formList, out var form, out var result))
+			{
+				return result ?? CommandResult.Fail("Error retrieving the form to update");
+			}
+
+			if (form == null || string.IsNullOrWhiteSpace(form.formxml))
+			{
+				return CommandResult.Fail("No formxml found!");
+			}
+
+			var eventName = GetEventName(command.Event);
+			var field = command.Event == FormEvent.OnChange ? command.Field : null;
+
+			if (command.Fast)
+			{
+				return await ExecuteFastAsync(crm, command, form, eventName, field, cancellationToken);
+			}
+
+			var (success, result1, solution) = await CreateHoldingSolutionAsync(crm, command.SolutionName);
+			if (!success) return result1 ?? CommandResult.Fail("Error creating the holding solution");
+			if (solution == null) return CommandResult.Fail("Error creating the holding solution");
+
+			using (solution)
+			{
+				try
+				{
+					await solution.AddComponentAsync(form.Id, ComponentType.SystemForm);
+
+					using var solutionContent = await solution.DownloadAsync();
+
+					if (!string.IsNullOrWhiteSpace(command.TempDir) && Directory.Exists(command.TempDir))
+					{
+						var fileName = Path.Combine(command.TempDir, $"{solution}_original.zip");
+						await solutionContent.SaveToAsync(fileName);
+						output.WriteLine($"Original form backup saved to {fileName}", ConsoleColor.DarkGray);
+					}
+
+					var hasChanges = solutionContent.UpdateEntryXml("customizations.xml", doc =>
+					{
+						var element = doc.XPathSelectElement("./ImportExportXml/Entities/Entity/FormXml/forms/systemform/form");
+						if (element == null)
+						{
+							throw new InvalidOperationException("The form element was not found in the customizations.xml of the temporary solution.");
+						}
+
+						output.Write($"Registering {command.Function} on the {eventName} event...");
+
+						var changed = FormEventXmlEditor.EnsureLibrary(element, command.Library);
+						changed = FormEventXmlEditor.EnsureHandler(element, eventName, field, command.Library, command.Function, command.PassExecutionContext) || changed;
+
+						output.WriteLine("Done", ConsoleColor.Green);
+						return changed;
+					});
+
+					if (hasChanges)
+					{
+						var newZipBytes = solutionContent.ToArray();
+						await solution.UploadAndPublishAsync(newZipBytes, command.TableName);
+					}
+					else
+					{
+						output.WriteLine("The handler is already registered on the form. No changes applied.", ConsoleColor.DarkGray);
+					}
+				}
+				catch (Exception ex)
+				{
+					output.WriteLine($"ERROR: {ex.Message}", ConsoleColor.Red);
+					return CommandResult.Fail(ex.Message, ex);
+				}
+			}
+
+			return CommandResult.Success();
+		}
+
+		private async Task<CommandResult> ExecuteFastAsync(IOrganizationServiceAsync2 crm, AddHandlerCommand command, Form form, string eventName, string? field, CancellationToken cancellationToken)
+		{
+			try
+			{
+				if (!string.IsNullOrWhiteSpace(command.TempDir) && Directory.Exists(command.TempDir))
+				{
+					var fileName = Path.Combine(command.TempDir, $"{command.TableName}_{form.name.OnlyLowercaseLettersNumbersOrUnderscore()}_original_formxml.xml");
+					await File.WriteAllTextAsync(fileName, form.formxml, cancellationToken);
+					output.WriteLine($"Original formxml backup saved to {fileName}", ConsoleColor.DarkGray);
+				}
+
+				var formElement = XElement.Parse(form.formxml);
+
+				output.Write($"Registering {command.Function} on the {eventName} event...");
+				var changed = FormEventXmlEditor.EnsureLibrary(formElement, command.Library);
+				changed = FormEventXmlEditor.EnsureHandler(formElement, eventName, field, command.Library, command.Function, command.PassExecutionContext) || changed;
+				output.WriteLine("Done", ConsoleColor.Green);
+
+				if (!changed)
+				{
+					output.WriteLine("The handler is already registered on the form. No changes applied.", ConsoleColor.DarkGray);
+					return CommandResult.Success();
+				}
+
+				output.Write("Updating the form...");
+				var update = new Entity("systemform", form.Id);
+				update["formxml"] = formElement.ToString(SaveOptions.DisableFormatting);
+				await crm.UpdateAsync(update, cancellationToken);
+				output.WriteLine("Done", ConsoleColor.Green);
+
+				output.Write("Publishing customizations...");
+				var publishRequest = new PublishXmlRequest
+				{
+					ParameterXml = $"<importexportxml><entities><entity>{command.TableName}</entity></entities></importexportxml>"
+				};
+				await crm.ExecuteAsync(publishRequest, cancellationToken);
+				output.WriteLine("Done", ConsoleColor.Green);
+
+				return CommandResult.Success();
+			}
+			catch (Exception ex)
+			{
+				output.WriteLine($"ERROR: {ex.Message}", ConsoleColor.Red);
+				return CommandResult.Fail(ex.Message, ex);
+			}
+		}
+
+		private static string GetEventName(FormEvent formEvent) => formEvent switch
+		{
+			FormEvent.OnSave => "onsave",
+			FormEvent.OnChange => "onchange",
+			_ => "onload"
+		};
+
+		private async Task<bool> CheckWebResourceExistsAsync(IOrganizationServiceAsync2 crm, string libraryName)
+		{
+			output.Write($"Checking webresource <{libraryName}>...");
+
+			var query = new QueryExpression("webresource")
+			{
+				NoLock = true,
+				TopCount = 1
+			};
+			query.ColumnSet.AddColumns("name");
+			query.Criteria.AddCondition("name", ConditionOperator.Equal, libraryName);
+
+			var response = await crm.RetrieveMultipleAsync(query);
+			if (response.Entities.Count == 0)
+			{
+				output.WriteLine("Failed", ConsoleColor.Red);
+				return false;
+			}
+
+			output.WriteLine("Done", ConsoleColor.Green);
+			return true;
+		}
+
+		private async Task<(bool, CommandResult?, ITemporarySolution?)> CreateHoldingSolutionAsync(IOrganizationServiceAsync2 crm, string? currentSolutionName)
+		{
+			if (string.IsNullOrWhiteSpace(currentSolutionName))
+			{
+				currentSolutionName = await organizationServiceRepository.GetCurrentDefaultSolutionAsync();
+				if (currentSolutionName == null)
+				{
+					return (false, CommandResult.Fail("No solution name provided and no current solution name found in the settings."), null);
+				}
+			}
+
+			output.Write($"Creating temporary holding solution...");
+			var currentSolution = await solutionRepository.GetByUniqueNameAsync(crm, currentSolutionName);
+			if (currentSolution == null)
+			{
+				return (false, CommandResult.Fail($"Solution {currentSolutionName} not found"), null);
+			}
+
+			var solution = await solutionRepository.CreateTemporarySolutionAsync(crm, currentSolution.publisherid);
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			return (true, null, solution);
+		}
+
+		private bool TryGetForm(string tableName, string formName, List<Form> formList, out Form? form, out CommandResult? result)
+		{
+			form = null;
+			result = null;
+
+			if (formList.Count == 0)
+			{
+				result = CommandResult.Fail($"No main form found for table {tableName}");
+				return false;
+			}
+
+			if (formList.Count == 1)
+			{
+				form = formList[0];
+				output.WriteLine($"Main form found: {form.name}");
+				return true;
+			}
+
+			if (string.IsNullOrWhiteSpace(formName))
+			{
+				result = CommandResult.Fail($"Table <{tableName}> has more than one main form. Please specify the form name using the --form parameter.");
+				return false;
+			}
+
+			formList = formList.Where(f => f.name.Equals(formName, StringComparison.OrdinalIgnoreCase)).ToList();
+			if (formList.Count == 0)
+			{
+				result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
+				return false;
+			}
+
+			if (formList.Count == 1)
+			{
+				form = formList[0];
+				output.WriteLine($"Main form found: {form.name}");
+				return true;
+			}
+
+			result = CommandResult.Fail($"Table <{tableName}> has more than one main form called <{formName}>. Please change the name of the form to uniquely identify it.");
+			return false;
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/AddHandlerCommandExecutor.cs
@@ -20,13 +20,18 @@ namespace Greg.Xrm.Command.Commands.Forms
 	{
 		public async Task<CommandResult> ExecuteAsync(AddHandlerCommand command, CancellationToken cancellationToken)
 		{
+			if (!string.IsNullOrWhiteSpace(command.TempDir) && !Directory.Exists(command.TempDir))
+			{
+				return CommandResult.Fail($"The --output directory <{command.TempDir}> does not exist. No changes have been applied.");
+			}
+
 			output.Write($"Connecting to the current dataverse environment...");
 			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
 			output.WriteLine("Done", ConsoleColor.Green);
 
 			if (!await CheckWebResourceExistsAsync(crm, command.Library))
 			{
-				return CommandResult.Fail($"Webresource <{command.Library}> not found in the current environment. The name must match exactly, check it via 'pacx webresources list' or in the maker portal.");
+				return CommandResult.Fail($"Webresource <{command.Library}> not found in the current environment, or it is not a javascript webresource. The name must match exactly, check it via the maker portal.");
 			}
 
 			output.Write($"Retrieving main form of table {command.TableName}...");
@@ -63,7 +68,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 					using var solutionContent = await solution.DownloadAsync();
 
-					if (!string.IsNullOrWhiteSpace(command.TempDir) && Directory.Exists(command.TempDir))
+					if (!string.IsNullOrWhiteSpace(command.TempDir))
 					{
 						var fileName = Path.Combine(command.TempDir, $"{solution}_original.zip");
 						await solutionContent.SaveToAsync(fileName);
@@ -111,7 +116,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 		{
 			try
 			{
-				if (!string.IsNullOrWhiteSpace(command.TempDir) && Directory.Exists(command.TempDir))
+				if (!string.IsNullOrWhiteSpace(command.TempDir))
 				{
 					var fileName = Path.Combine(command.TempDir, $"{command.TableName}_{form.name.OnlyLowercaseLettersNumbersOrUnderscore()}_original_formxml.xml");
 					await File.WriteAllTextAsync(fileName, form.formxml, cancellationToken);
@@ -172,6 +177,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 			};
 			query.ColumnSet.AddColumns("name");
 			query.Criteria.AddCondition("name", ConditionOperator.Equal, libraryName);
+			query.Criteria.AddCondition("webresourcetype", ConditionOperator.Equal, (int)WebResourceType.Script);
 
 			var response = await crm.RetrieveMultipleAsync(query);
 			if (response.Entities.Count == 0)
@@ -221,6 +227,12 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 			if (formList.Count == 1)
 			{
+				if (!string.IsNullOrWhiteSpace(formName) && !formList[0].name.Equals(formName, StringComparison.OrdinalIgnoreCase))
+				{
+					result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
+					return false;
+				}
+
 				form = formList[0];
 				output.WriteLine($"Main form found: {form.name}");
 				return true;

--- a/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
@@ -1,0 +1,118 @@
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	/// <summary>
+	/// Manipulates the formLibraries and events sections of a formxml document,
+	/// producing the same structure the form designer writes.
+	/// </summary>
+	public static class FormEventXmlEditor
+	{
+		/// <summary>
+		/// Ensures the given webresource is referenced in the formLibraries section.
+		/// Returns true when the document has been changed.
+		/// </summary>
+		public static bool EnsureLibrary(XElement form, string libraryName)
+		{
+			var libraries = form.Element("formLibraries");
+			if (libraries == null)
+			{
+				libraries = new XElement("formLibraries");
+
+				// in exported forms the events section comes before formLibraries
+				var events = form.Element("events");
+				if (events != null)
+				{
+					events.AddAfterSelf(libraries);
+				}
+				else
+				{
+					form.Add(libraries);
+				}
+			}
+
+			var alreadyThere = libraries.Elements("Library")
+				.Any(l => string.Equals(l.Attribute("name")?.Value, libraryName, StringComparison.OrdinalIgnoreCase));
+			if (alreadyThere)
+			{
+				return false;
+			}
+
+			libraries.Add(new XElement("Library",
+				new XAttribute("name", libraryName),
+				new XAttribute("libraryUniqueId", Guid.NewGuid().ToString("B"))));
+			return true;
+		}
+
+		/// <summary>
+		/// Ensures the given handler is registered on the given event.
+		/// For the onchange event, <paramref name="field"/> identifies the column to watch.
+		/// Returns true when the document has been changed, false when the same
+		/// function of the same library is already registered on the event.
+		/// </summary>
+		public static bool EnsureHandler(XElement form, string eventName, string? field, string libraryName, string functionName, bool passExecutionContext)
+		{
+			var events = form.Element("events");
+			if (events == null)
+			{
+				events = new XElement("events");
+
+				// in exported forms the events section comes before formLibraries
+				var libraries = form.Element("formLibraries");
+				if (libraries != null)
+				{
+					libraries.AddBeforeSelf(events);
+				}
+				else
+				{
+					form.Add(events);
+				}
+			}
+
+			var eventElement = events.Elements("event")
+				.FirstOrDefault(e =>
+					string.Equals(e.Attribute("name")?.Value, eventName, StringComparison.OrdinalIgnoreCase)
+					&& (field == null || string.Equals(e.Attribute("attribute")?.Value, field, StringComparison.OrdinalIgnoreCase)));
+
+			if (eventElement == null)
+			{
+				eventElement = new XElement("event",
+					new XAttribute("name", eventName),
+					new XAttribute("application", "false"),
+					new XAttribute("active", "false"));
+
+				if (field != null)
+				{
+					eventElement.SetAttributeValue("attribute", field);
+				}
+
+				events.Add(eventElement);
+			}
+
+			var handlers = eventElement.Element("Handlers");
+			if (handlers == null)
+			{
+				handlers = new XElement("Handlers");
+				eventElement.Add(handlers);
+			}
+
+			var alreadyThere = handlers.Elements("Handler")
+				.Any(h => string.Equals(h.Attribute("functionName")?.Value, functionName, StringComparison.OrdinalIgnoreCase)
+					&& string.Equals(h.Attribute("libraryName")?.Value, libraryName, StringComparison.OrdinalIgnoreCase));
+			if (alreadyThere)
+			{
+				return false;
+			}
+
+			handlers.Add(new XElement("Handler",
+				new XAttribute("functionName", functionName),
+				new XAttribute("libraryName", libraryName),
+				new XAttribute("handlerUniqueId", Guid.NewGuid().ToString("B")),
+				new XAttribute("enabled", "true"),
+				new XAttribute("parameters", ""),
+				new XAttribute("passExecutionContext", passExecutionContext ? "true" : "false")));
+			return true;
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
@@ -49,7 +49,8 @@ namespace Greg.Xrm.Command.Commands.Forms
 		/// Ensures the given handler is registered on the given event.
 		/// For the onchange event, <paramref name="field"/> identifies the column to watch.
 		/// Returns true when the document has been changed, false when the same
-		/// function of the same library is already registered on the event.
+		/// function of the same library is already registered on the event with
+		/// the same passExecutionContext setting.
 		/// </summary>
 		public static bool EnsureHandler(XElement form, string eventName, string? field, string libraryName, string functionName, bool passExecutionContext)
 		{
@@ -97,12 +98,21 @@ namespace Greg.Xrm.Command.Commands.Forms
 				eventElement.Add(handlers);
 			}
 
-			var alreadyThere = handlers.Elements("Handler")
-				.Any(h => string.Equals(h.Attribute("functionName")?.Value, functionName, StringComparison.OrdinalIgnoreCase)
+			var existing = handlers.Elements("Handler")
+				.FirstOrDefault(h => string.Equals(h.Attribute("functionName")?.Value, functionName, StringComparison.OrdinalIgnoreCase)
 					&& string.Equals(h.Attribute("libraryName")?.Value, libraryName, StringComparison.OrdinalIgnoreCase));
-			if (alreadyThere)
+			if (existing != null)
 			{
-				return false;
+				// the handler is already registered, but the requested
+				// passExecutionContext setting may differ from the stored one
+				var requested = passExecutionContext ? "true" : "false";
+				if (string.Equals(existing.Attribute("passExecutionContext")?.Value, requested, StringComparison.OrdinalIgnoreCase))
+				{
+					return false;
+				}
+
+				existing.SetAttributeValue("passExecutionContext", requested);
+				return true;
 			}
 
 			handlers.Add(new XElement("Handler",

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/AddHandlerCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/AddHandlerCommandExecutorTest.cs
@@ -1,0 +1,126 @@
+using Greg.Xrm.Command.Commands.Forms.Model;
+using Greg.Xrm.Command.Model;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class AddHandlerCommandExecutorTest : CommandExecutorTestBase
+	{
+		private readonly AddHandlerCommandExecutor executor;
+		private readonly Mock<IFormRepository> formRepositoryMock = new();
+		private readonly Mock<ISolutionRepository> solutionRepositoryMock = new();
+		private QueryExpression? capturedQuery;
+
+		public AddHandlerCommandExecutorTest()
+		{
+			this.executor = new AddHandlerCommandExecutor(
+				this.OrganizationServiceRepositoryMock.Object,
+				this.Output,
+				this.formRepositoryMock.Object,
+				this.solutionRepositoryMock.Object);
+		}
+
+		// ── helpers ───────────────────────────────────────────────────────────
+
+		private void SetupWebResourceResponse(params Entity[] rows)
+		{
+			this.OrganizationServiceMock
+				.Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>()))
+				.Callback<QueryBase>(qb => this.capturedQuery = qb as QueryExpression)
+				.ReturnsAsync(new EntityCollection(rows.ToList()));
+		}
+
+		private static Form CreateForm(string name)
+		{
+			var entity = new Entity("systemform", Guid.NewGuid());
+			entity["name"] = name;
+			entity["formxml"] = "<form><tabs /></form>";
+			return new Form(entity);
+		}
+
+		private static AddHandlerCommand CreateCommand() => new()
+		{
+			TableName = "account",
+			Library = "myprefix_scripts.js",
+			Function = "My.Account.onLoad"
+		};
+
+		// ── --output validation ───────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenOutputDirectoryDoesNotExist()
+		{
+			var command = CreateCommand();
+			command.TempDir = "C:\\this\\folder\\does\\not\\exist\\at\\all";
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not exist");
+		}
+
+		// ── webresource type check ────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldRequireJavascriptWebresource()
+		{
+			SetupWebResourceResponse();
+			var command = CreateCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "javascript");
+
+			Assert.IsNotNull(this.capturedQuery);
+			var typeCondition = this.capturedQuery.Criteria.Conditions
+				.SingleOrDefault(c => c.AttributeName == "webresourcetype");
+			Assert.IsNotNull(typeCondition, "The webresource lookup must filter on the resource type.");
+			Assert.AreEqual((int)WebResourceType.Script, typeCondition.Values[0]);
+		}
+
+		// ── form resolution ───────────────────────────────────────────────────
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenFormNameDoesNotMatchTheOnlyForm()
+		{
+			SetupWebResourceResponse(new Entity("webresource", Guid.NewGuid()));
+			this.formRepositoryMock
+				.Setup(r => r.GetMainFormByTableNameAsync(It.IsAny<Microsoft.PowerPlatform.Dataverse.Client.IOrganizationServiceAsync2>(), "account"))
+				.ReturnsAsync([CreateForm("Information")]);
+
+			var command = CreateCommand();
+			command.FormName = "DoesNotExist";
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "not found");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldAcceptMatchingFormName_WhenTableHasOneForm()
+		{
+			SetupWebResourceResponse(new Entity("webresource", Guid.NewGuid()));
+			this.formRepositoryMock
+				.Setup(r => r.GetMainFormByTableNameAsync(It.IsAny<Microsoft.PowerPlatform.Dataverse.Client.IOrganizationServiceAsync2>(), "account"))
+				.ReturnsAsync([CreateForm("Information")]);
+			this.solutionRepositoryMock
+				.Setup(r => r.GetByUniqueNameAsync(It.IsAny<Microsoft.PowerPlatform.Dataverse.Client.IOrganizationServiceAsync2>(), It.IsAny<string>()))
+				.ReturnsAsync((Greg.Xrm.Command.Model.Solution?)null);
+
+			var command = CreateCommand();
+			command.FormName = "information";
+			command.SolutionName = "SomeSolution";
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			// the run fails later at the solution lookup, which proves the
+			// case-insensitive form name match was accepted
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "SomeSolution");
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/AddHandlerCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/AddHandlerCommandTest.cs
@@ -1,0 +1,157 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class AddHandlerCommandTest
+	{
+		// ── parsing ───────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void ParseWithLongNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"--table", "account",
+				"--library", "myprefix_scripts.js",
+				"--function", "My.Account.onLoad");
+
+			Assert.AreEqual("account", command.TableName);
+			Assert.AreEqual("myprefix_scripts.js", command.Library);
+			Assert.AreEqual("My.Account.onLoad", command.Function);
+			Assert.AreEqual(FormEvent.OnLoad, command.Event);
+			Assert.IsTrue(command.PassExecutionContext);
+			Assert.IsNull(command.Field);
+		}
+
+		[TestMethod]
+		public void ParseWithShortNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onNameChange",
+				"-e", "OnChange",
+				"-col", "name");
+
+			Assert.AreEqual("account", command.TableName);
+			Assert.AreEqual(FormEvent.OnChange, command.Event);
+			Assert.AreEqual("name", command.Field);
+		}
+
+		[TestMethod]
+		public void FastShouldDefaultToFalseAndBeSettable()
+		{
+			var command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onLoad");
+
+			Assert.IsFalse(command.Fast);
+
+			command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onLoad",
+				"--fast", "true");
+
+			Assert.IsTrue(command.Fast);
+		}
+
+		[TestMethod]
+		public void OutputOptionShouldWork()
+		{
+			var command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onLoad",
+				"--output", "C:\\temp");
+
+			Assert.AreEqual("C:\\temp", command.TempDir);
+		}
+
+		[TestMethod]
+		public void PassContextCanBeDisabled()
+		{
+			var command = Utility.TestParseCommand<AddHandlerCommand>(
+				"forms", "addhandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onLoad",
+				"--passContext", "false");
+
+			Assert.IsFalse(command.PassExecutionContext);
+		}
+
+		// ── validation ────────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void ValidateShouldFailWhenOnChangeHasNoField()
+		{
+			var command = new AddHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onNameChange",
+				Event = FormEvent.OnChange
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldFailWhenFieldIsUsedWithoutOnChange()
+		{
+			var command = new AddHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onLoad",
+				Event = FormEvent.OnLoad,
+				Field = "name"
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldPassForOnChangeWithField()
+		{
+			var command = new AddHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onNameChange",
+				Event = FormEvent.OnChange,
+				Field = "name"
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldPassForPlainOnLoad()
+		{
+			var command = new AddHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onLoad"
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
@@ -1,0 +1,192 @@
+using System.Xml.Linq;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class FormEventXmlEditorTest
+	{
+		private static XElement CreateEmptyForm() => new("form", new XElement("tabs"));
+
+		// ── EnsureLibrary ─────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void EnsureLibrary_ShouldCreateSectionAndEntry_WhenMissing()
+		{
+			var form = CreateEmptyForm();
+
+			var changed = FormEventXmlEditor.EnsureLibrary(form, "myprefix_scripts.js");
+
+			Assert.IsTrue(changed);
+			var library = form.Element("formLibraries")?.Element("Library");
+			Assert.IsNotNull(library);
+			Assert.AreEqual("myprefix_scripts.js", library.Attribute("name")?.Value);
+			Assert.IsFalse(string.IsNullOrWhiteSpace(library.Attribute("libraryUniqueId")?.Value));
+		}
+
+		[TestMethod]
+		public void EnsureLibrary_ShouldDoNothing_WhenLibraryAlreadyReferenced()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureLibrary(form, "myprefix_scripts.js");
+
+			var changed = FormEventXmlEditor.EnsureLibrary(form, "MYPREFIX_scripts.js");
+
+			Assert.IsFalse(changed);
+			Assert.AreEqual(1, form.Element("formLibraries")!.Elements("Library").Count());
+		}
+
+		[TestMethod]
+		public void EnsureLibrary_ShouldAppendToExistingSection()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureLibrary(form, "myprefix_a.js");
+
+			var changed = FormEventXmlEditor.EnsureLibrary(form, "myprefix_b.js");
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(2, form.Element("formLibraries")!.Elements("Library").Count());
+		}
+
+		// ── EnsureHandler ─────────────────────────────────────────────────────
+
+		[TestMethod]
+		public void EnsureHandler_ShouldCreateEventAndHandler_ForOnLoad()
+		{
+			var form = CreateEmptyForm();
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			Assert.IsTrue(changed);
+			var eventElement = form.Element("events")?.Element("event");
+			Assert.IsNotNull(eventElement);
+			Assert.AreEqual("onload", eventElement.Attribute("name")?.Value);
+			Assert.IsNull(eventElement.Attribute("attribute"));
+
+			var handler = eventElement.Element("Handlers")?.Element("Handler");
+			Assert.IsNotNull(handler);
+			Assert.AreEqual("My.Account.onLoad", handler.Attribute("functionName")?.Value);
+			Assert.AreEqual("myprefix_scripts.js", handler.Attribute("libraryName")?.Value);
+			Assert.AreEqual("true", handler.Attribute("enabled")?.Value);
+			Assert.AreEqual("true", handler.Attribute("passExecutionContext")?.Value);
+			Assert.IsFalse(string.IsNullOrWhiteSpace(handler.Attribute("handlerUniqueId")?.Value));
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldSetAttribute_ForOnChange()
+		{
+			var form = CreateEmptyForm();
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onchange", "name", "myprefix_scripts.js", "My.Account.onNameChange", true);
+
+			Assert.IsTrue(changed);
+			var eventElement = form.Element("events")?.Element("event");
+			Assert.IsNotNull(eventElement);
+			Assert.AreEqual("onchange", eventElement.Attribute("name")?.Value);
+			Assert.AreEqual("name", eventElement.Attribute("attribute")?.Value);
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldBeIdempotent_ForSameFunctionAndLibrary()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			Assert.IsFalse(changed);
+			Assert.AreEqual(1, form.Descendants("Handler").Count());
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldAppendSecondHandler_OnSameEvent()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.initRibbon", true);
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, form.Element("events")!.Elements("event").Count(), "Both handlers should live under the same event element.");
+			Assert.AreEqual(2, form.Descendants("Handler").Count());
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldCreateSeparateEvents_ForDifferentFields()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureHandler(form, "onchange", "name", "myprefix_scripts.js", "My.Account.onNameChange", true);
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onchange", "telephone1", "myprefix_scripts.js", "My.Account.onPhoneChange", true);
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(2, form.Element("events")!.Elements("event").Count());
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldRespectPassContextFalse()
+		{
+			var form = CreateEmptyForm();
+
+			FormEventXmlEditor.EnsureHandler(form, "onsave", null, "myprefix_scripts.js", "My.Account.onSave", false);
+
+			var handler = form.Descendants("Handler").Single();
+			Assert.AreEqual("false", handler.Attribute("passExecutionContext")?.Value);
+		}
+
+		[TestMethod]
+		public void EnsureHandler_ShouldReuseExistingEventElement_FromTheDesigner()
+		{
+			// simulates a form where the designer already registered another handler
+			var form = new XElement("form",
+				new XElement("tabs"),
+				new XElement("events",
+					new XElement("event",
+						new XAttribute("name", "onload"),
+						new XAttribute("application", "false"),
+						new XAttribute("active", "false"),
+						new XElement("Handlers",
+							new XElement("Handler",
+								new XAttribute("functionName", "Other.onLoad"),
+								new XAttribute("libraryName", "myprefix_other.js"),
+								new XAttribute("handlerUniqueId", "{11111111-1111-1111-1111-111111111111}"),
+								new XAttribute("enabled", "true"),
+								new XAttribute("parameters", ""),
+								new XAttribute("passExecutionContext", "true"))))));
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, form.Element("events")!.Elements("event").Count());
+			Assert.AreEqual(2, form.Descendants("Handler").Count());
+		}
+
+		// ── element ordering ──────────────────────────────────────────────────
+
+		[TestMethod]
+		public void EventsShouldComeBeforeFormLibraries_WhenBothAreCreated()
+		{
+			var form = CreateEmptyForm();
+
+			FormEventXmlEditor.EnsureLibrary(form, "myprefix_scripts.js");
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			var children = form.Elements().Select(e => e.Name.LocalName).ToList();
+			var eventsIndex = children.IndexOf("events");
+			var librariesIndex = children.IndexOf("formLibraries");
+			Assert.IsTrue(eventsIndex >= 0 && librariesIndex >= 0);
+			Assert.IsTrue(eventsIndex < librariesIndex, "The events section must precede formLibraries, like in designer-exported forms.");
+		}
+
+		[TestMethod]
+		public void EventsShouldComeBeforeFormLibraries_RegardlessOfCallOrder()
+		{
+			var form = CreateEmptyForm();
+
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+			FormEventXmlEditor.EnsureLibrary(form, "myprefix_scripts.js");
+
+			var children = form.Elements().Select(e => e.Name.LocalName).ToList();
+			Assert.IsTrue(children.IndexOf("events") < children.IndexOf("formLibraries"));
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
@@ -98,6 +98,19 @@ namespace Greg.Xrm.Command.Commands.Forms
 		}
 
 		[TestMethod]
+		public void EnsureHandler_ShouldUpdatePassContext_WhenItDiffers()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			var changed = FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", false);
+
+			Assert.IsTrue(changed, "Changing passExecutionContext must count as a change.");
+			var handler = form.Descendants("Handler").Single();
+			Assert.AreEqual("false", handler.Attribute("passExecutionContext")?.Value);
+		}
+
+		[TestMethod]
 		public void EnsureHandler_ShouldAppendSecondHandler_OnSameEvent()
 		{
 			var form = CreateEmptyForm();


### PR DESCRIPTION
Registering event handlers on forms is the onE step of my webresource deployments that always forces me back into the browser. Even teams that wire up everything in code need at least one trip to the designer per form, since the initial onLoad handler can only be registered through configuration. In our team it is more than one trip, our convention is that handlers should be visible in the designer, so registering them in code is not an option for us at all. As far as I can tell there is no CLI way to do this today, neither in pac nor in pacx, so I built one. Feel free to close this if it doesn't fit the tool.

The command registers a javascript event handler on the main form of a table. It writes the same formLibraries and events entries into the formxml that the form designer writes, so the registration stays visible and editable in the designer afterwards. You pick the table with `--table`, the webresource with `--library` (the command checks that it exists and adds it to the form when it is not referenced yet), the function with `--function` and the event with `--event` (OnLoad by default, OnSave, or OnChange together with `--field`). Running the same command twice changes nothing.

By default the form is updated through a temporary solution, the same way forms clean does it. Since that roundtrip takes a few minutes there is also a `--fast` flag that updates the formxml of the form directly and publishes, which takes seconds. In both modes `--output` saves a backup of the original form before any change is applied.

```
pacx forms addhandler -t account -l new_scripts.js -fn My.Account.onLoad
pacx forms addhandler -t account -l new_scripts.js -fn My.Account.onNameChange -e OnChange --field name --fast
```

Your AppMaker videos actually confirmed the idea for me. If I remember correctly, when the copilot attached the onLoad handler there it first invented a FormActivation element that doesn't exist and needed a second attempt to get the formxml right. That is exactly the kind of guesswork a dedicated command avoids, and it also gives a copilot something reliable to call instead of writing raw formxml itself.