### PR TITLE
Fix build pipeline after the net10 move

### DIFF
--- a/.github/workflows/build-pipeline-01.yml
+++ b/.github/workflows/build-pipeline-01.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     # Restore nuget dependencies
     - name: Restore Dependencies
@@ -108,7 +108,7 @@ jobs:
         
     - name: Update Wiki content
       run: |
-        .\Greg.Xrm.Command\bin\Release\net8.0\pacx.exe --export ${{ github.workspace }}/wiki
+        .\Greg.Xrm.Command\bin\Release\net10.0\pacx.exe --export ${{ github.workspace }}/wiki
 
     - name: Push documentation to wiki
       uses: actions4gh/deploy-wiki@v1


### PR DESCRIPTION
I was looking for the plugin trace list page in the wiki, noticed it was missing, and that the plugin page itself has not been touched since March, so I dug into the build pipeline. The workflow still installs the 8.0 SDK and looks for pacx under bin/Release/net8.0, both left over from the net10 migration. The version tag is pushed before the build, so tags kept appearing, but the last github release and the last version on nuget.org are both 1.2026.7.232 from July 25, and the wiki no longer updates. So it looks like every run since the migration dies at one of these two spots before anything gets published, and none of the recent merges have reached users yet.
This aligns the two references with the current target framework. I cannot run the pipeline from a fork, so I could not test it, but I did not find anything else in the workflow that depends on the framework version.