### PR TITLE
Stricter checks for forms clean

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Forms/CleanCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/CleanCommandExecutor.cs
@@ -19,6 +19,11 @@ namespace Greg.Xrm.Command.Commands.Forms
 	{
 		public async Task<CommandResult> ExecuteAsync(CleanCommand command, CancellationToken cancellationToken)
 		{
+			if (!string.IsNullOrWhiteSpace(command.TempDir) && !Directory.Exists(command.TempDir))
+			{
+				return CommandResult.Fail($"The --output directory <{command.TempDir}> does not exist. No changes have been applied.");
+			}
+
 			output.Write($"Connecting to the current dataverse environment...");
 			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
 			output.WriteLine("Done", ConsoleColor.Green);
@@ -68,7 +73,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 					// now I need to download the solution, extract the customizations.xml file, modify it, and re-upload it
 					using (var solutionContent = await solution.DownloadAsync())
 					{
-						if (!string.IsNullOrWhiteSpace(command.TempDir) && Directory.Exists(command.TempDir))
+						if (!string.IsNullOrWhiteSpace(command.TempDir))
 						{
 							var fileName = Path.Combine(command.TempDir, $"{solution}_original.zip");
 							await solutionContent.SaveToAsync(fileName);
@@ -151,6 +156,12 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 			if (formList.Count == 1)
 			{
+				if (!string.IsNullOrWhiteSpace(formName) && !formList[0].name.Equals(formName, StringComparison.OrdinalIgnoreCase))
+				{
+					result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
+					return false;
+				}
+
 				form = formList[0];
 				output.WriteLine($"Main form found: {form.name}");
 				return true;

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/CleanCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/CleanCommandExecutorTest.cs
@@ -1,0 +1,65 @@
+using Greg.Xrm.Command.Commands.Forms.Model;
+using Greg.Xrm.Command.Model;
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class CleanCommandExecutorTest : CommandExecutorTestBase
+	{
+		private readonly CleanCommandExecutor executor;
+		private readonly Mock<IFormRepository> formRepositoryMock = new();
+		private readonly Mock<ISolutionRepository> solutionRepositoryMock = new();
+
+		public CleanCommandExecutorTest()
+		{
+			this.executor = new CleanCommandExecutor(
+				this.OrganizationServiceRepositoryMock.Object,
+				this.Output,
+				this.formRepositoryMock.Object,
+				this.solutionRepositoryMock.Object);
+		}
+
+		private static Form CreateForm(string name)
+		{
+			var entity = new Entity("systemform", Guid.NewGuid());
+			entity["name"] = name;
+			entity["formxml"] = "<form><tabs /></form>";
+			return new Form(entity);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenOutputDirectoryDoesNotExist()
+		{
+			var command = new CleanCommand
+			{
+				TableName = "account",
+				TempDir = "C:\\this\\folder\\does\\not\\exist\\at\\all"
+			};
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not exist");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenFormNameDoesNotMatchTheOnlyForm()
+		{
+			this.formRepositoryMock
+				.Setup(r => r.GetMainFormByTableNameAsync(It.IsAny<Microsoft.PowerPlatform.Dataverse.Client.IOrganizationServiceAsync2>(), "account"))
+				.ReturnsAsync([CreateForm("Information")]);
+
+			var command = new CleanCommand
+			{
+				TableName = "account",
+				FormName = "DoesNotExist"
+			};
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "not found");
+		}
+	}
+}


### PR DESCRIPTION
As announced in #230, the two review findings there apply to forms clean as well, since the new command had mirrored its behavior. With this change the command fails upfront when the --output directory does not exist, instead of silently skipping the backup and modifying the form anyway. And a --form value that does not match is now rejected also when the table has only one main form, instead of being silently ignored. Both checks are covered by executor tests.
I left the duplicated form lookup between clean and addhandler untouched for now, extracting a shared helper would conflict with the open PR. Happy to do that refactoring once #230 is settled, if you want that.