### PR TITLE
Add 'pacx forms removehandler' as counterpart of addhandler

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Forms/CleanCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/CleanCommandExecutor.cs
@@ -36,7 +36,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 			var formList = await formRepository.GetMainFormByTableNameAsync(crm, command.TableName);
 			output.WriteLine("Done", ConsoleColor.Green);
 
-			if (!TryGetForm(command.TableName, command.FormName, formList, out var form, out var result))
+			if (!FormCommandHelpers.TryGetForm(output, command.TableName, command.FormName, formList, out var form, out var result))
 			{
 				return result ?? CommandResult.Fail("Error retrieving the form to update");
 			}
@@ -59,7 +59,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 
 
-			var (success, result1, solution) = await CreateHoldingSolutionAsync(crm, command.SolutionName);
+			var (success, result1, solution) = await FormCommandHelpers.CreateHoldingSolutionAsync(organizationServiceRepository, solutionRepository, output, crm, command.SolutionName);
 			if (!success) return result1 ?? CommandResult.Fail("Error creating the holding solution");
 			if (solution == null) return CommandResult.Fail("Error creating the holding solution");
 
@@ -114,85 +114,11 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 
 
-		private async Task<(bool, CommandResult?, ITemporarySolution?)> CreateHoldingSolutionAsync(IOrganizationServiceAsync2 crm, string? currentSolutionName)
-		{
-			if (string.IsNullOrWhiteSpace(currentSolutionName))
-			{
-				currentSolutionName = await organizationServiceRepository.GetCurrentDefaultSolutionAsync();
-				if (currentSolutionName == null)
-				{
-					return (false, CommandResult.Fail("No solution name provided and no current solution name found in the settings."), null);
-				}
-			}
-
-			output.Write($"Creating temporary holding solution...");
-			var currentSolution = await solutionRepository.GetByUniqueNameAsync(crm, currentSolutionName);
-			if (currentSolution == null)
-			{
-				return (false, CommandResult.Fail($"Solution {currentSolutionName} not found"), null);
-			}
-
-			var solution = await solutionRepository.CreateTemporarySolutionAsync(crm, currentSolution.publisherid);
-			output.WriteLine("Done", ConsoleColor.Green);
-
-
-			return (true, null, solution);
-		}
 
 
 
 
 
-		private bool TryGetForm(string tableName, string formName, List<Form> formList, out Form? form, out CommandResult? result)
-		{
-			form = null;
-			result = null;
-
-			if (formList.Count == 0)
-			{
-				result = CommandResult.Fail($"No main form found for table {tableName}");
-				return false;
-			}
-
-			if (formList.Count == 1)
-			{
-				if (!string.IsNullOrWhiteSpace(formName) && !formList[0].name.Equals(formName, StringComparison.OrdinalIgnoreCase))
-				{
-					result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
-					return false;
-				}
-
-				form = formList[0];
-				output.WriteLine($"Main form found: {form.name}");
-				return true;
-			}
-
-
-			// if we are here, we have more tan 1 form
-
-			if (string.IsNullOrWhiteSpace(formName))
-			{
-				result = CommandResult.Fail($"Table <{tableName}> has more than one main form. Please specify the form name using the --form parameter.");
-				return false;
-			}
-
-			formList = formList.Where(f => f.name.Equals(formName, StringComparison.OrdinalIgnoreCase)).ToList();
-			if (formList.Count == 0)
-			{
-				result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
-				return false;
-			}
-
-			if (formList.Count == 1)
-			{
-				form = formList[0];
-				output.WriteLine($"Main form found: {form.name}");
-				return true;
-			}
-
-			result = CommandResult.Fail($"Table <{tableName}> has more than one main form called <{formName}>. Please change the name of the form to uniquely identify it.");
-			return false;
-		}
 
 
 		private async Task<EntityMetadata> RetrieveEntityMetadataAsync(IOrganizationServiceAsync2 crm, string tableName)

--- a/Greg.Xrm.Command.Core/Commands/Forms/FormCommandHelpers.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/FormCommandHelpers.cs
@@ -1,0 +1,101 @@
+using Greg.Xrm.Command.Commands.Forms.Model;
+using Greg.Xrm.Command.Model;
+using Greg.Xrm.Command.Services.Connection;
+using Greg.Xrm.Command.Services.Output;
+using Microsoft.PowerPlatform.Dataverse.Client;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	/// <summary>
+	/// Logic shared by the commands of the forms group.
+	/// </summary>
+	internal static class FormCommandHelpers
+	{
+		/// <summary>
+		/// Picks the main form to work on from the list of main forms of a table.
+		/// When the table has more than one main form (or a form name has been
+		/// provided explicitly), the form name must match exactly.
+		/// </summary>
+		public static bool TryGetForm(IOutput output, string tableName, string formName, List<Form> formList, out Form? form, out CommandResult? result)
+		{
+			form = null;
+			result = null;
+
+			if (formList.Count == 0)
+			{
+				result = CommandResult.Fail($"No main form found for table {tableName}");
+				return false;
+			}
+
+			if (formList.Count == 1)
+			{
+				if (!string.IsNullOrWhiteSpace(formName) && !formList[0].name.Equals(formName, StringComparison.OrdinalIgnoreCase))
+				{
+					result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
+					return false;
+				}
+
+				form = formList[0];
+				output.WriteLine($"Main form found: {form.name}");
+				return true;
+			}
+
+			if (string.IsNullOrWhiteSpace(formName))
+			{
+				result = CommandResult.Fail($"Table <{tableName}> has more than one main form. Please specify the form name using the --form parameter.");
+				return false;
+			}
+
+			formList = formList.Where(f => f.name.Equals(formName, StringComparison.OrdinalIgnoreCase)).ToList();
+			if (formList.Count == 0)
+			{
+				result = CommandResult.Fail($"Main form <{formName}> not found for table <{tableName}>");
+				return false;
+			}
+
+			if (formList.Count == 1)
+			{
+				form = formList[0];
+				output.WriteLine($"Main form found: {form.name}");
+				return true;
+			}
+
+			result = CommandResult.Fail($"Table <{tableName}> has more than one main form called <{formName}>. Please change the name of the form to uniquely identify it.");
+			return false;
+		}
+
+		/// <summary>
+		/// Creates the temporary holding solution used to update a form through
+		/// a solution roundtrip. The publisher of the given solution (or of the
+		/// current default solution) is used for the temporary solution.
+		/// </summary>
+		public static async Task<(bool, CommandResult?, ITemporarySolution?)> CreateHoldingSolutionAsync(
+			IOrganizationServiceRepository organizationServiceRepository,
+			ISolutionRepository solutionRepository,
+			IOutput output,
+			IOrganizationServiceAsync2 crm,
+			string? currentSolutionName)
+		{
+			if (string.IsNullOrWhiteSpace(currentSolutionName))
+			{
+				currentSolutionName = await organizationServiceRepository.GetCurrentDefaultSolutionAsync();
+				if (currentSolutionName == null)
+				{
+					return (false, CommandResult.Fail("No solution name provided and no current solution name found in the settings."), null);
+				}
+			}
+
+			output.Write($"Creating temporary holding solution...");
+			var currentSolution = await solutionRepository.GetByUniqueNameAsync(crm, currentSolutionName);
+			if (currentSolution == null)
+			{
+				return (false, CommandResult.Fail($"Solution {currentSolutionName} not found"), null);
+			}
+
+			var solution = await solutionRepository.CreateTemporarySolutionAsync(crm, currentSolution.publisherid);
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			return (true, null, solution);
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Forms/FormCommandHelpers.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/FormCommandHelpers.cs
@@ -14,7 +14,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 		/// <summary>
 		/// Picks the main form to work on from the list of main forms of a table.
 		/// When the table has more than one main form (or a form name has been
-		/// provided explicitly), the form name must match exactly.
+	/// provided explicitly), it must identify exactly one form; name matching is case-insensitive.
 		/// </summary>
 		public static bool TryGetForm(IOutput output, string tableName, string formName, List<Form> formList, out Form? form, out CommandResult? result)
 		{

--- a/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/FormEventXmlEditor.cs
@@ -124,5 +124,81 @@ namespace Greg.Xrm.Command.Commands.Forms
 				new XAttribute("passExecutionContext", passExecutionContext ? "true" : "false")));
 			return true;
 		}
+
+		/// <summary>
+		/// Removes the given handler from the given event. Event containers that
+		/// remain empty are pruned, so the document ends up the same way the
+		/// designer would leave it. For the onchange event, <paramref name="field"/>
+		/// identifies the column being watched.
+		/// Returns true when the document has been changed, false when the handler
+		/// was not registered.
+		/// </summary>
+		public static bool RemoveHandler(XElement form, string eventName, string? field, string libraryName, string functionName)
+		{
+			var events = form.Element("events");
+			var eventElement = events?.Elements("event")
+				.FirstOrDefault(e => string.Equals(e.Attribute("name")?.Value, eventName, StringComparison.OrdinalIgnoreCase)
+					&& (field == null || string.Equals(e.Attribute("attribute")?.Value, field, StringComparison.OrdinalIgnoreCase)));
+
+			var handlers = eventElement?.Element("Handlers");
+			var handler = handlers?.Elements("Handler")
+				.FirstOrDefault(h => string.Equals(h.Attribute("functionName")?.Value, functionName, StringComparison.OrdinalIgnoreCase)
+					&& string.Equals(h.Attribute("libraryName")?.Value, libraryName, StringComparison.OrdinalIgnoreCase));
+
+			if (handler == null)
+			{
+				return false;
+			}
+
+			handler.Remove();
+
+			if (!handlers!.Elements().Any())
+			{
+				eventElement!.Remove();
+			}
+
+			if (!events!.Elements().Any())
+			{
+				events.Remove();
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Returns true when any handler of any event still references the given library.
+		/// </summary>
+		public static bool IsLibraryReferenced(XElement form, string libraryName)
+		{
+			return form.Element("events")?
+				.Descendants("Handler")
+				.Any(h => string.Equals(h.Attribute("libraryName")?.Value, libraryName, StringComparison.OrdinalIgnoreCase)) ?? false;
+		}
+
+		/// <summary>
+		/// Removes the given webresource from the formLibraries section, pruning
+		/// the section when it remains empty.
+		/// Returns true when the document has been changed.
+		/// </summary>
+		public static bool RemoveLibrary(XElement form, string libraryName)
+		{
+			var libraries = form.Element("formLibraries");
+			var library = libraries?.Elements("Library")
+				.FirstOrDefault(l => string.Equals(l.Attribute("name")?.Value, libraryName, StringComparison.OrdinalIgnoreCase));
+
+			if (library == null)
+			{
+				return false;
+			}
+
+			library.Remove();
+
+			if (!libraries!.Elements().Any())
+			{
+				libraries.Remove();
+			}
+
+			return true;
+		}
 	}
 }

--- a/Greg.Xrm.Command.Core/Commands/Forms/RemoveHandlerCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/RemoveHandlerCommand.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel.DataAnnotations;
+using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[Command("forms", "removehandler", HelpText = "Removes a javascript event handler from the main form of a given table")]
+	[Alias("form", "removehandler")]
+	public class RemoveHandlerCommand : IValidatableObject, ICanProvideUsageExample
+	{
+		[Option("table", "t", Order = 1, HelpText = "The name of the table to which the form belongs")]
+		[Required]
+		public string TableName { get; set; } = string.Empty;
+
+		[Option("library", "l", Order = 2, HelpText = "The name of the javascript webresource that contains the handler function (e.g. myprefix_/scripts/account.js)")]
+		[Required]
+		public string Library { get; set; } = string.Empty;
+
+		[Option("function", "fn", Order = 3, HelpText = "The name of the function to remove, including its namespace (e.g. My.Account.onLoad)")]
+		[Required]
+		public string Function { get; set; } = string.Empty;
+
+		[Option("event", "e", Order = 4, HelpText = "The form event to remove the handler from.", DefaultValue = FormEvent.OnLoad)]
+		public FormEvent Event { get; set; } = FormEvent.OnLoad;
+
+		[Option("field", "col", Order = 5, HelpText = "The logical name of the watched column. Required for (and only valid with) the OnChange event.")]
+		public string? Field { get; set; }
+
+		[Option("form", "f", Order = 6, HelpText = "The name of the form to update. It is required only if the table has more than one Main form.")]
+		public string FormName { get; set; } = string.Empty;
+
+		[Option("solution", "s", Order = 7, HelpText = "The name of the solution that contains the table. If not provided, the default solution will be used")]
+		public string? SolutionName { get; set; }
+
+		[Option("output", "out", Order = 8, HelpText = "If specified, the command will export the original version of the form in the specified folder before applying any change. The folder must exist.")]
+		public string? TempDir { get; set; }
+
+		[Option("fast", "ft", Order = 9, HelpText = "Updates the formxml of the form directly instead of going through a temporary solution. Much faster; the platform still validates the formxml on update, but the all-or-nothing safety of a solution import is skipped.", DefaultValue = false)]
+		public bool Fast { get; set; } = false;
+
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			if (Event == FormEvent.OnChange && string.IsNullOrWhiteSpace(Field))
+			{
+				yield return new ValidationResult("The --field argument is required for the OnChange event.", [nameof(Field)]);
+			}
+
+			if (Event != FormEvent.OnChange && !string.IsNullOrWhiteSpace(Field))
+			{
+				yield return new ValidationResult("The --field argument can only be used with the OnChange event.", [nameof(Field)]);
+			}
+		}
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("Counterpart of 'forms addhandler'. Removes a handler registration from the form definition, the same way deleting it in the form designer would.");
+
+			writer.WriteParagraph("Remove an OnLoad handler from the main form of a table:");
+			writer.WriteCodeBlock("pacx forms removehandler --table account --library myprefix_scripts.js --function My.Account.onLoad", "Powershell");
+
+			writer.WriteParagraph("Remove an OnChange handler from a specific column:");
+			writer.WriteCodeBlock("pacx forms removehandler -t account -l myprefix_scripts.js -fn My.Account.onNameChange -e OnChange --field name", "Powershell");
+
+			writer.WriteParagraph("When the removed handler was the last one referencing the webresource library, the library is removed from the form as well. Event entries that remain empty are cleaned up, so the form definition ends up the same way the designer would leave it. If the handler is not registered, the command makes no change, so it is safe to run repeatedly.");
+
+			writer.WriteParagraph("The command does not check whether the webresource still exists in the environment, so it can also be used to clean up registrations of webresources that have already been deleted.");
+
+			writer.WriteParagraph("Use --output to save a backup of the original form before any change is applied. By default the form is updated through a temporary solution, use --fast to update the formxml directly instead, which takes seconds instead of minutes:");
+			writer.WriteCodeBlock("pacx forms removehandler -t account -l myprefix_scripts.js -fn My.Account.onLoad --fast --output C:\\temp", "Powershell");
+
+			writer.WriteParagraph("Please note: unless --fast is used, the command needs to create a temporary solution in the target environment. The temporary solution is deleted automatically once the operation is complete.");
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Forms/RemoveHandlerCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Forms/RemoveHandlerCommandExecutor.cs
@@ -7,18 +7,17 @@ using Greg.Xrm.Command.Services.Output;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Query;
 
 namespace Greg.Xrm.Command.Commands.Forms
 {
-	public class AddHandlerCommandExecutor
+	public class RemoveHandlerCommandExecutor
 	(
 			IOrganizationServiceRepository organizationServiceRepository,
 			IOutput output,
 			IFormRepository formRepository,
-			ISolutionRepository solutionRepository) : ICommandExecutor<AddHandlerCommand>
+			ISolutionRepository solutionRepository) : ICommandExecutor<RemoveHandlerCommand>
 	{
-		public async Task<CommandResult> ExecuteAsync(AddHandlerCommand command, CancellationToken cancellationToken)
+		public async Task<CommandResult> ExecuteAsync(RemoveHandlerCommand command, CancellationToken cancellationToken)
 		{
 			if (!string.IsNullOrWhiteSpace(command.TempDir) && !Directory.Exists(command.TempDir))
 			{
@@ -29,10 +28,8 @@ namespace Greg.Xrm.Command.Commands.Forms
 			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
 			output.WriteLine("Done", ConsoleColor.Green);
 
-			if (!await CheckWebResourceExistsAsync(crm, command.Library))
-			{
-				return CommandResult.Fail($"Webresource <{command.Library}> not found in the current environment, or it is not a javascript webresource. The name must match exactly, check it via the maker portal.");
-			}
+			// no webresource existence check here on purpose, the command must also
+			// be able to clean up registrations of already deleted webresources
 
 			output.Write($"Retrieving main form of table {command.TableName}...");
 			var formList = await formRepository.GetMainFormByTableNameAsync(crm, command.TableName);
@@ -83,11 +80,8 @@ namespace Greg.Xrm.Command.Commands.Forms
 							throw new InvalidOperationException("The form element was not found in the customizations.xml of the temporary solution.");
 						}
 
-						output.Write($"Registering {command.Function} on the {eventName} event...");
-
-						var changed = FormEventXmlEditor.EnsureLibrary(element, command.Library);
-						changed = FormEventXmlEditor.EnsureHandler(element, eventName, field, command.Library, command.Function, command.PassExecutionContext) || changed;
-
+						output.Write($"Removing {command.Function} from the {eventName} event...");
+						var changed = RemoveHandlerAndUnusedLibrary(element, eventName, field, command.Library, command.Function);
 						output.WriteLine("Done", ConsoleColor.Green);
 						return changed;
 					});
@@ -99,7 +93,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 					}
 					else
 					{
-						output.WriteLine("The handler is already registered on the form. No changes applied.", ConsoleColor.DarkGray);
+						output.WriteLine("The handler is not registered on the form. No changes applied.", ConsoleColor.DarkGray);
 					}
 				}
 				catch (Exception ex)
@@ -112,7 +106,7 @@ namespace Greg.Xrm.Command.Commands.Forms
 			return CommandResult.Success();
 		}
 
-		private async Task<CommandResult> ExecuteFastAsync(IOrganizationServiceAsync2 crm, AddHandlerCommand command, Form form, string eventName, string? field, CancellationToken cancellationToken)
+		private async Task<CommandResult> ExecuteFastAsync(IOrganizationServiceAsync2 crm, RemoveHandlerCommand command, Form form, string eventName, string? field, CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -125,14 +119,13 @@ namespace Greg.Xrm.Command.Commands.Forms
 
 				var formElement = XElement.Parse(form.formxml);
 
-				output.Write($"Registering {command.Function} on the {eventName} event...");
-				var changed = FormEventXmlEditor.EnsureLibrary(formElement, command.Library);
-				changed = FormEventXmlEditor.EnsureHandler(formElement, eventName, field, command.Library, command.Function, command.PassExecutionContext) || changed;
+				output.Write($"Removing {command.Function} from the {eventName} event...");
+				var changed = RemoveHandlerAndUnusedLibrary(formElement, eventName, field, command.Library, command.Function);
 				output.WriteLine("Done", ConsoleColor.Green);
 
 				if (!changed)
 				{
-					output.WriteLine("The handler is already registered on the form. No changes applied.", ConsoleColor.DarkGray);
+					output.WriteLine("The handler is not registered on the form. No changes applied.", ConsoleColor.DarkGray);
 					return CommandResult.Success();
 				}
 
@@ -159,36 +152,23 @@ namespace Greg.Xrm.Command.Commands.Forms
 			}
 		}
 
+		private static bool RemoveHandlerAndUnusedLibrary(XElement form, string eventName, string? field, string libraryName, string functionName)
+		{
+			var changed = FormEventXmlEditor.RemoveHandler(form, eventName, field, libraryName, functionName);
+
+			if (changed && !FormEventXmlEditor.IsLibraryReferenced(form, libraryName))
+			{
+				FormEventXmlEditor.RemoveLibrary(form, libraryName);
+			}
+
+			return changed;
+		}
+
 		private static string GetEventName(FormEvent formEvent) => formEvent switch
 		{
 			FormEvent.OnSave => "onsave",
 			FormEvent.OnChange => "onchange",
 			_ => "onload"
 		};
-
-		private async Task<bool> CheckWebResourceExistsAsync(IOrganizationServiceAsync2 crm, string libraryName)
-		{
-			output.Write($"Checking webresource <{libraryName}>...");
-
-			var query = new QueryExpression("webresource")
-			{
-				NoLock = true,
-				TopCount = 1
-			};
-			query.ColumnSet.AddColumns("name");
-			query.Criteria.AddCondition("name", ConditionOperator.Equal, libraryName);
-			query.Criteria.AddCondition("webresourcetype", ConditionOperator.Equal, (int)WebResourceType.Script);
-
-			var response = await crm.RetrieveMultipleAsync(query);
-			if (response.Entities.Count == 0)
-			{
-				output.WriteLine("Failed", ConsoleColor.Red);
-				return false;
-			}
-
-			output.WriteLine("Done", ConsoleColor.Green);
-			return true;
-		}
-
 	}
 }

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/FormEventXmlEditorTest.cs
@@ -173,6 +173,122 @@ namespace Greg.Xrm.Command.Commands.Forms
 			Assert.AreEqual(2, form.Descendants("Handler").Count());
 		}
 
+		// ── RemoveHandler / RemoveLibrary ─────────────────────────────────────
+
+		private static XElement CreateFormWithOnLoadHandler()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureLibrary(form, "myprefix_scripts.js");
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+			return form;
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldRemoveHandlerAndPruneEmptyContainers()
+		{
+			var form = CreateFormWithOnLoadHandler();
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad");
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(0, form.Descendants("Handler").Count());
+			Assert.IsNull(form.Element("events"), "Empty event containers must be pruned like the designer does.");
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldDoNothing_WhenHandlerIsNotRegistered()
+		{
+			var form = CreateFormWithOnLoadHandler();
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.doesNotExist");
+
+			Assert.IsFalse(changed);
+			Assert.AreEqual(1, form.Descendants("Handler").Count());
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldKeepOtherHandlersAndTheEvent()
+		{
+			var form = CreateFormWithOnLoadHandler();
+			FormEventXmlEditor.EnsureHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.initRibbon", true);
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad");
+
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, form.Descendants("Handler").Count());
+			Assert.IsNotNull(form.Element("events")?.Element("event"), "The event must survive while it still has handlers.");
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldOnlyTouchTheMatchingFieldEvent()
+		{
+			var form = CreateEmptyForm();
+			FormEventXmlEditor.EnsureHandler(form, "onchange", "name", "myprefix_scripts.js", "My.Account.onNameChange", true);
+			FormEventXmlEditor.EnsureHandler(form, "onchange", "telephone1", "myprefix_scripts.js", "My.Account.onPhoneChange", true);
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "onchange", "name", "myprefix_scripts.js", "My.Account.onNameChange");
+
+			Assert.IsTrue(changed);
+			var remainingEvent = form.Element("events")!.Elements("event").Single();
+			Assert.AreEqual("telephone1", remainingEvent.Attribute("attribute")?.Value);
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldOnlyTouchTheMatchingEvent()
+		{
+			var form = CreateFormWithOnLoadHandler();
+			FormEventXmlEditor.EnsureHandler(form, "onsave", null, "myprefix_scripts.js", "My.Account.onLoad", true);
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "onsave", null, "myprefix_scripts.js", "My.Account.onLoad");
+
+			Assert.IsTrue(changed);
+			var remainingEvent = form.Element("events")!.Elements("event").Single();
+			Assert.AreEqual("onload", remainingEvent.Attribute("name")?.Value, "The same function on another event must survive.");
+			Assert.IsTrue(FormEventXmlEditor.IsLibraryReferenced(form, "myprefix_scripts.js"));
+		}
+
+		[TestMethod]
+		public void RemoveHandler_ShouldMatchCaseInsensitive()
+		{
+			var form = CreateFormWithOnLoadHandler();
+
+			var changed = FormEventXmlEditor.RemoveHandler(form, "OnLoad", null, "MYPREFIX_scripts.js", "my.account.ONLOAD");
+
+			Assert.IsTrue(changed, "Matching must be case insensitive, like the rest of the editor.");
+			Assert.AreEqual(0, form.Descendants("Handler").Count());
+		}
+
+		[TestMethod]
+		public void IsLibraryReferenced_ShouldReflectRemainingHandlers()
+		{
+			var form = CreateFormWithOnLoadHandler();
+			Assert.IsTrue(FormEventXmlEditor.IsLibraryReferenced(form, "myprefix_scripts.js"));
+
+			FormEventXmlEditor.RemoveHandler(form, "onload", null, "myprefix_scripts.js", "My.Account.onLoad");
+			Assert.IsFalse(FormEventXmlEditor.IsLibraryReferenced(form, "myprefix_scripts.js"));
+		}
+
+		[TestMethod]
+		public void RemoveLibrary_ShouldRemoveEntryAndPruneEmptySection()
+		{
+			var form = CreateFormWithOnLoadHandler();
+
+			var changed = FormEventXmlEditor.RemoveLibrary(form, "myprefix_scripts.js");
+
+			Assert.IsTrue(changed);
+			Assert.IsNull(form.Element("formLibraries"), "An empty formLibraries section must be pruned.");
+		}
+
+		[TestMethod]
+		public void RemoveLibrary_ShouldDoNothing_WhenLibraryIsNotReferenced()
+		{
+			var form = CreateEmptyForm();
+
+			var changed = FormEventXmlEditor.RemoveLibrary(form, "myprefix_scripts.js");
+
+			Assert.IsFalse(changed);
+		}
+
 		// ── element ordering ──────────────────────────────────────────────────
 
 		[TestMethod]

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/RemoveHandlerCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/RemoveHandlerCommandExecutorTest.cs
@@ -1,0 +1,126 @@
+using Greg.Xrm.Command.Commands.Forms.Model;
+using Greg.Xrm.Command.Model;
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class RemoveHandlerCommandExecutorTest : CommandExecutorTestBase
+	{
+		private readonly RemoveHandlerCommandExecutor executor;
+		private readonly Mock<IFormRepository> formRepositoryMock = new();
+		private readonly Mock<ISolutionRepository> solutionRepositoryMock = new();
+		private Entity? updatedEntity;
+
+		public RemoveHandlerCommandExecutorTest()
+		{
+			this.executor = new RemoveHandlerCommandExecutor(
+				this.OrganizationServiceRepositoryMock.Object,
+				this.Output,
+				this.formRepositoryMock.Object,
+				this.solutionRepositoryMock.Object);
+
+			this.OrganizationServiceMock
+				.Setup(s => s.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()))
+				.Callback<Entity, CancellationToken>((e, _) => this.updatedEntity = e)
+				.Returns(Task.CompletedTask);
+
+			this.OrganizationServiceMock
+				.Setup(s => s.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+				.ReturnsAsync(new OrganizationResponse());
+		}
+
+		private const string FormXmlWithHandler =
+			"<form><tabs /><events><event name=\"onload\" application=\"false\" active=\"false\">" +
+			"<Handlers><Handler functionName=\"My.Account.onLoad\" libraryName=\"myprefix_scripts.js\" " +
+			"handlerUniqueId=\"{11111111-1111-1111-1111-111111111111}\" enabled=\"true\" parameters=\"\" " +
+			"passExecutionContext=\"true\" /></Handlers></event></events>" +
+			"<formLibraries><Library name=\"myprefix_scripts.js\" libraryUniqueId=\"{22222222-2222-2222-2222-222222222222}\" /></formLibraries></form>";
+
+		private void SetupForm(string formXml)
+		{
+			var entity = new Entity("systemform", Guid.NewGuid());
+			entity["name"] = "Information";
+			entity["formxml"] = formXml;
+			this.formRepositoryMock
+				.Setup(r => r.GetMainFormByTableNameAsync(It.IsAny<Microsoft.PowerPlatform.Dataverse.Client.IOrganizationServiceAsync2>(), "account"))
+				.ReturnsAsync([new Form(entity)]);
+		}
+
+		private static RemoveHandlerCommand CreateCommand() => new()
+		{
+			TableName = "account",
+			Library = "myprefix_scripts.js",
+			Function = "My.Account.onLoad",
+			Fast = true
+		};
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenOutputDirectoryDoesNotExist()
+		{
+			var command = CreateCommand();
+			command.TempDir = "C:\\this\\folder\\does\\not\\exist\\at\\all";
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not exist");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldMakeNoChange_WhenHandlerIsNotRegistered()
+		{
+			SetupForm("<form><tabs /></form>");
+			var command = CreateCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			Assert.IsNull(this.updatedEntity, "Nothing must be written when the handler is not registered.");
+			StringAssert.Contains(this.Output.ToString(), "not registered");
+		}
+
+		private const string FormXmlWithHandlerOnTwoEvents =
+			"<form><tabs /><events><event name=\"onload\" application=\"false\" active=\"false\">" +
+			"<Handlers><Handler functionName=\"My.Account.onLoad\" libraryName=\"myprefix_scripts.js\" " +
+			"handlerUniqueId=\"{11111111-1111-1111-1111-111111111111}\" enabled=\"true\" parameters=\"\" " +
+			"passExecutionContext=\"true\" /></Handlers></event>" +
+			"<event name=\"onsave\" application=\"false\" active=\"false\">" +
+			"<Handlers><Handler functionName=\"My.Account.onLoad\" libraryName=\"myprefix_scripts.js\" " +
+			"handlerUniqueId=\"{33333333-3333-3333-3333-333333333333}\" enabled=\"true\" parameters=\"\" " +
+			"passExecutionContext=\"true\" /></Handlers></event></events>" +
+			"<formLibraries><Library name=\"myprefix_scripts.js\" libraryUniqueId=\"{22222222-2222-2222-2222-222222222222}\" /></formLibraries></form>";
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldKeepLibrary_WhenStillReferencedByAnotherEvent()
+		{
+			SetupForm(FormXmlWithHandlerOnTwoEvents);
+			var command = CreateCommand();
+			command.Event = FormEvent.OnSave;
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			Assert.IsNotNull(this.updatedEntity);
+			var newFormXml = (string)this.updatedEntity["formxml"];
+			Assert.IsFalse(newFormXml.Contains("onsave"), "The onsave registration must be removed.");
+			Assert.IsTrue(newFormXml.Contains("\"onload\""), "The onload registration must survive.");
+			Assert.IsTrue(newFormXml.Contains("formLibraries"), "The library must stay while another event references it.");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldRemoveHandlerAndUnusedLibrary_InFastMode()
+		{
+			SetupForm(FormXmlWithHandler);
+			var command = CreateCommand();
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			Assert.IsNotNull(this.updatedEntity);
+			var newFormXml = (string)this.updatedEntity["formxml"];
+			Assert.IsFalse(newFormXml.Contains("My.Account.onLoad"), "The handler must be removed.");
+			Assert.IsFalse(newFormXml.Contains("myprefix_scripts.js"), "The unreferenced library must be removed as well.");
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/RemoveHandlerCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Forms/RemoveHandlerCommandTest.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.Forms
+{
+	[TestClass]
+	public class RemoveHandlerCommandTest
+	{
+		[TestMethod]
+		public void ParseWithLongNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<RemoveHandlerCommand>(
+				"forms", "removehandler",
+				"--table", "account",
+				"--library", "myprefix_scripts.js",
+				"--function", "My.Account.onLoad");
+
+			Assert.AreEqual("account", command.TableName);
+			Assert.AreEqual("myprefix_scripts.js", command.Library);
+			Assert.AreEqual("My.Account.onLoad", command.Function);
+			Assert.AreEqual(FormEvent.OnLoad, command.Event);
+			Assert.IsFalse(command.Fast);
+		}
+
+		[TestMethod]
+		public void ParseWithShortNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<RemoveHandlerCommand>(
+				"forms", "removehandler",
+				"-t", "account",
+				"-l", "myprefix_scripts.js",
+				"-fn", "My.Account.onNameChange",
+				"-e", "OnChange",
+				"-col", "name");
+
+			Assert.AreEqual(FormEvent.OnChange, command.Event);
+			Assert.AreEqual("name", command.Field);
+		}
+
+		[TestMethod]
+		public void ValidateShouldFailWhenOnChangeHasNoField()
+		{
+			var command = new RemoveHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onNameChange",
+				Event = FormEvent.OnChange
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldFailWhenFieldIsUsedWithoutOnChange()
+		{
+			var command = new RemoveHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onLoad",
+				Event = FormEvent.OnLoad,
+				Field = "name"
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldPassForPlainOnLoad()
+		{
+			var command = new RemoveHandlerCommand
+			{
+				TableName = "account",
+				Library = "myprefix_scripts.js",
+				Function = "My.Account.onLoad"
+			};
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+	}
+}


### PR DESCRIPTION
Counterpart of forms addhandler. Removes a javascript event handler from the main form of a table, the same way deleting it in the form designer would.

When the removed handler was the last one referencing the webresource library, the library is removed from the form as well. Event entries that remain empty are cleaned up, so the form definition ends up the same as if the change had been made in the designer. Removing a handler that is not registered makes no change, so the command is safe to run repeatedly.

The command intentionally does not check whether the webresource still exists. That way it can also clean up registrations of webresources that have already been deleted.

Options, the solution roundtrip default and the fast and output flags behave like in addhandler. I also moved the form lookup and the temporary solution creation that clean and addhandler had duplicated into a shared FormCommandHelpers class, as offered in #232, instead of adding a third copy.

Comes with tests for the xml editor, the parser, the validation and the executor. I also tested both update paths live on a throwaway table, including removing only one of two registrations that share the same function, and the designer shows the expected result.