### PR TITLE
Let 'pacx view replicate' keep the components and the sort order of the target views

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommand.cs
@@ -17,6 +17,12 @@ namespace Greg.Xrm.Command.Commands.Views
 		[Option("onto", "o", Order = 3, HelpText = "The name of the views that should be updated with the new layout, separated by comma (,). If not specified, all saved queries except for lookup views will be updated. If * is provided as value, all views will be updated (lookup views included).")]
 		public string? Onto { get; set; }
 
+		[Option("keepcomponents", "kc", Order = 4, HelpText = "Keeps the custom controls of the target views instead of replacing them with the ones of the source view.", DefaultValue = false)]
+		public bool KeepComponents { get; set; } = false;
+
+		[Option("keepsorting", "ks", Order = 5, HelpText = "Keeps the sort order of the target views instead of replacing it with the one of the source view.", DefaultValue = false)]
+		public bool KeepSorting { get; set; } = false;
+
 
 
 		public void WriteUsageExamples(MarkdownWriter writer)
@@ -43,6 +49,11 @@ namespace Greg.Xrm.Command.Commands.Views
 			writer.WriteCodeBlock("pacx view replicate -n \"My View\" -t greg_table -o \"View 1,View 2,View 3\"", "Powershell");
 
 			writer.WriteLine("Separating the view names via comma (,).");
+			writer.WriteLine();
+
+			writer.WriteParagraph("By default, the replication also copies the sort order and the custom controls of the source view onto the target views. When the target views have their own sorting or their own custom controls (e.g. the Power Apps grid control) that should survive the replication, you can keep them by typing: ");
+
+			writer.WriteCodeBlock("pacx view replicate -n \"My View\" -t greg_table --keepsorting --keepcomponents", "Powershell");
 		}
 	}
 }

--- a/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommand.cs
@@ -17,10 +17,10 @@ namespace Greg.Xrm.Command.Commands.Views
 		[Option("onto", "o", Order = 3, HelpText = "The name of the views that should be updated with the new layout, separated by comma (,). If not specified, all saved queries except for lookup views will be updated. If * is provided as value, all views will be updated (lookup views included).")]
 		public string? Onto { get; set; }
 
-		[Option("keepcomponents", "kc", Order = 4, HelpText = "Keeps the custom controls of the target views instead of replacing them with the ones of the source view.", DefaultValue = false)]
+		[Option("keepComponents", "kc", Order = 4, HelpText = "Keeps the custom controls of the target views instead of replacing them with the ones of the source view.", DefaultValue = false)]
 		public bool KeepComponents { get; set; } = false;
 
-		[Option("keepsorting", "ks", Order = 5, HelpText = "Keeps the sort order of the target views instead of replacing it with the one of the source view.", DefaultValue = false)]
+		[Option("keepSorting", "ks", Order = 5, HelpText = "Keeps the sort order of the target views instead of replacing it with the one of the source view.", DefaultValue = false)]
 		public bool KeepSorting { get; set; } = false;
 
 
@@ -53,7 +53,7 @@ namespace Greg.Xrm.Command.Commands.Views
 
 			writer.WriteParagraph("By default, the replication also copies the sort order and the custom controls of the source view onto the target views. When the target views have their own sorting or their own custom controls (e.g. the Power Apps grid control) that should survive the replication, you can keep them by typing: ");
 
-			writer.WriteCodeBlock("pacx view replicate -n \"My View\" -t greg_table --keepsorting --keepcomponents", "Powershell");
+			writer.WriteCodeBlock("pacx view replicate -n \"My View\" -t greg_table --keepSorting --keepComponents", "Powershell");
 		}
 	}
 }

--- a/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Views/ReplicateCommandExecutor.cs
@@ -68,7 +68,10 @@ namespace Greg.Xrm.Command.Commands.Views
 			{
 				output.Write("Replicating layout, please wait...");
 
-				var operationResult = await Replicator.PropagateLayoutAsync(crm, (SavedQuery)view, otherViews, true, true, true);
+				var operationResult = await Replicator.PropagateLayoutAsync(crm, (SavedQuery)view, otherViews,
+					includeLayout: true,
+					includeSorting: !command.KeepSorting,
+					includeComponents: !command.KeepComponents);
 
 
 				if (operationResult.Count > 0)

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicateCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicateCommandTest.cs
@@ -1,0 +1,46 @@
+namespace Greg.Xrm.Command.Commands.Views
+{
+	[TestClass]
+	public class ReplicateCommandTest
+	{
+		[TestMethod]
+		public void ParseWithLongNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<ReplicateCommand>(
+				"view", "replicate",
+				"--name", "My View",
+				"--table", "account",
+				"--keepcomponents", "true",
+				"--keepsorting", "true");
+
+			Assert.AreEqual("My View", command.ViewName);
+			Assert.AreEqual("account", command.TableName);
+			Assert.IsTrue(command.KeepComponents);
+			Assert.IsTrue(command.KeepSorting);
+		}
+
+		[TestMethod]
+		public void ParseWithShortNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<ReplicateCommand>(
+				"view", "replicate",
+				"-n", "My View",
+				"-kc", "true",
+				"-ks", "true");
+
+			Assert.IsTrue(command.KeepComponents);
+			Assert.IsTrue(command.KeepSorting);
+		}
+
+		[TestMethod]
+		public void ParseShouldReplicateEverythingByDefault()
+		{
+			var command = Utility.TestParseCommand<ReplicateCommand>(
+				"view", "replicate",
+				"--name", "My View");
+
+			Assert.IsFalse(command.KeepComponents);
+			Assert.IsFalse(command.KeepSorting);
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicatorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicatorTest.cs
@@ -1,0 +1,101 @@
+using Greg.Xrm.Command.Commands.Views.Model;
+using Greg.Xrm.Command.Model;
+using Microsoft.Crm.Sdk;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Views
+{
+	[TestClass]
+	public class ReplicatorTest
+	{
+		private const string SourceLayout =
+			"<grid name=\"resultset\" object=\"1\" jump=\"name\" select=\"1\" icon=\"1\" preview=\"1\">" +
+			"<row name=\"result\" id=\"accountid\">" +
+			"<cell name=\"name\" width=\"300\" /><cell name=\"telephone1\" width=\"100\" />" +
+			"</row></grid>";
+
+		private const string SourceFetch =
+			"<fetch version=\"1.0\"><entity name=\"account\">" +
+			"<attribute name=\"name\" /><attribute name=\"telephone1\" />" +
+			"<order attribute=\"name\" descending=\"false\" />" +
+			"</entity></fetch>";
+
+		private const string TargetLayoutWithCustomControl =
+			"<grid name=\"resultset\" object=\"1\" jump=\"name\" select=\"1\" icon=\"1\" preview=\"1\">" +
+			"<row name=\"result\" id=\"accountid\">" +
+			"<cell name=\"name\" width=\"150\" />" +
+			"</row>" +
+			"<controlDescriptions><controlDescription forControl=\"{00000000-0000-0000-0000-000000000000}\">" +
+			"<customControl name=\"MscrmControls.Grid.PcfGridControl\" />" +
+			"</controlDescription></controlDescriptions></grid>";
+
+		private const string TargetFetch =
+			"<fetch version=\"1.0\"><entity name=\"account\">" +
+			"<attribute name=\"name\" />" +
+			"<order attribute=\"createdon\" descending=\"true\" />" +
+			"</entity></fetch>";
+
+		private readonly Mock<IOrganizationServiceAsync2> crmMock = new();
+
+		public ReplicatorTest()
+		{
+			this.crmMock
+				.Setup(s => s.UpdateAsync(It.IsAny<Entity>()))
+				.Returns(Task.CompletedTask);
+		}
+
+		private static SavedQuery CreateView(string name, string layoutXml, string fetchXml)
+		{
+			var entity = new Entity("savedquery", Guid.NewGuid());
+			entity["name"] = name;
+			entity["querytype"] = SavedQueryQueryType.MainApplicationView;
+			entity["returnedtypecode"] = "account";
+			entity["layoutxml"] = layoutXml;
+			entity["fetchxml"] = fetchXml;
+			return new SavedQuery(entity);
+		}
+
+		[TestMethod]
+		public async Task PropagateLayout_ShouldReplaceComponentsAndSorting_ByDefault()
+		{
+			var source = CreateView("Source", SourceLayout, SourceFetch);
+			var target = CreateView("Target", TargetLayoutWithCustomControl, TargetFetch);
+
+			var errors = await Replicator.PropagateLayoutAsync(this.crmMock.Object, source, [target]);
+
+			Assert.AreEqual(0, errors.Count);
+			Assert.IsTrue(target.layoutxml!.Contains("telephone1"), "The column layout must be replicated.");
+			Assert.IsFalse(target.layoutxml.Contains("controlDescriptions"), "By default the components of the target are replaced by the ones of the source, which has none.");
+			Assert.IsTrue(target.fetchxml!.Contains("order attribute=\"name\""), "By default the sort order of the source wins.");
+			Assert.IsFalse(target.fetchxml.Contains("order attribute=\"createdon\""));
+		}
+
+		[TestMethod]
+		public async Task PropagateLayout_ShouldKeepTargetComponents_WhenComponentsAreExcluded()
+		{
+			var source = CreateView("Source", SourceLayout, SourceFetch);
+			var target = CreateView("Target", TargetLayoutWithCustomControl, TargetFetch);
+
+			var errors = await Replicator.PropagateLayoutAsync(this.crmMock.Object, source, [target], includeComponents: false);
+
+			Assert.AreEqual(0, errors.Count);
+			Assert.IsTrue(target.layoutxml!.Contains("telephone1"), "The column layout must still be replicated.");
+			Assert.IsTrue(target.layoutxml.Contains("MscrmControls.Grid.PcfGridControl"), "The custom control of the target must survive.");
+		}
+
+		[TestMethod]
+		public async Task PropagateLayout_ShouldKeepTargetSorting_WhenSortingIsExcluded()
+		{
+			var source = CreateView("Source", SourceLayout, SourceFetch);
+			var target = CreateView("Target", TargetLayoutWithCustomControl, TargetFetch);
+
+			var errors = await Replicator.PropagateLayoutAsync(this.crmMock.Object, source, [target], includeSorting: false);
+
+			Assert.AreEqual(0, errors.Count);
+			Assert.IsTrue(target.fetchxml!.Contains("order attribute=\"createdon\""), "The sort order of the target must survive.");
+			Assert.IsFalse(target.fetchxml.Contains("order attribute=\"name\""));
+			Assert.IsTrue(target.layoutxml!.Contains("telephone1"), "The column layout must still be replicated.");
+		}
+	}
+}


### PR DESCRIPTION
Fixes #148.
Replicating a view currently also replaces the custom controls and the sort order of the target views. When the source view has no custom controls, the ones of the targets are deleted outright. 
The switches for this already exist in the replication logic, they were just hardcoded. This change exposes two of them. With --keepcomponents the target views keep their own custom controls, with --keepsorting their own sort order. Without the new options the behavior is unchanged.

