### PR TITLE
Fix script table failing on options without a label in the language of the user

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/ColumnScriptGeneratorForPicklist.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/ColumnScriptGeneratorForPicklist.cs
@@ -15,7 +15,7 @@ namespace Greg.Xrm.Command.Commands.Script.Service.ColumnScriptGenerators
 			}
 			else
 			{
-				var options = field.OptionSet.Options.Select(o => $"{o.Label.UserLocalizedLabel.Label}:{o.Value}");
+				var options = field.OptionSet.Options.Select(o => $"{o.Label.GetTextOrDefault(o.Value?.ToString() ?? string.Empty)}:{o.Value}");
 				script.Append($" --options \"{string.Join(",", options)}\"");
 			}
 

--- a/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/ColumnScriptGeneratorForStatus.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/ColumnScriptGeneratorForStatus.cs
@@ -15,7 +15,7 @@ namespace Greg.Xrm.Command.Commands.Script.Service.ColumnScriptGenerators
 			foreach (var stateOption in stateOptions)
 			{
 				script.Append("## STATE: ");
-				script.Append(stateOption.Label.UserLocalizedLabel.Label);
+				script.Append(stateOption.Label.GetTextOrDefault(stateOption.Value?.ToString() ?? string.Empty));
 				script.Append(" (");
 				script.Append(stateOption.Value);
 				script.Append(")");
@@ -34,7 +34,7 @@ namespace Greg.Xrm.Command.Commands.Script.Service.ColumnScriptGenerators
 					script.Append(" --value ");
 					script.Append(child.Value);
 					script.Append(" --label ");
-					script.Append(child.Label.UserLocalizedLabel.Label);
+					script.Append(child.Label.GetTextOrDefault(child.Value?.ToString() ?? string.Empty));
 
 					if (!string.IsNullOrWhiteSpace(child.Color))
 					{

--- a/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/LabelExtensions.cs
+++ b/Greg.Xrm.Command.Core/Commands/Script/Service/ColumnScriptGenerators/LabelExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Script.Service.ColumnScriptGenerators
+{
+	/// <summary>
+	/// On environments where the language of the current user differs from the
+	/// language the labels have been authored in, UserLocalizedLabel can be null.
+	/// Picks the best label available instead of failing.
+	/// </summary>
+	public static class LabelExtensions
+	{
+		private const int English = 1033;
+
+		public static string GetTextOrDefault(this Label? label, string fallback)
+		{
+			return label?.UserLocalizedLabel?.Label
+				?? label?.LocalizedLabels?.FirstOrDefault(l => l.LanguageCode == English && !string.IsNullOrWhiteSpace(l.Label))?.Label
+				?? label?.LocalizedLabels?.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l.Label))?.Label
+				?? fallback;
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Script/ScriptBuilderLabelFallbackTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Script/ScriptBuilderLabelFallbackTest.cs
@@ -1,0 +1,111 @@
+using Greg.Xrm.Command.Commands.Script.Models;
+using Greg.Xrm.Command.Commands.Script.Service;
+using Greg.Xrm.Command.Commands.Script.Service.ColumnScriptGenerators;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace Greg.Xrm.Command.Commands.Script
+{
+	/// <summary>
+	/// On environments where the user language differs from the language the labels
+	/// have been authored in, UserLocalizedLabel is null on the affected options.
+	/// The script generation must fall back to another label instead of failing.
+	/// </summary>
+	[TestClass]
+	public class ScriptBuilderLabelFallbackTest
+	{
+		[TestMethod]
+		public void GetTextOrDefault_ShouldPreferUserLocalizedLabel()
+		{
+			var label = new Label("User language", 1033) { UserLocalizedLabel = new LocalizedLabel("User language", 1033) };
+
+			Assert.AreEqual("User language", label.GetTextOrDefault("fallback"));
+		}
+
+		[TestMethod]
+		public void GetTextOrDefault_ShouldPreferEnglish_WhenTheUserLanguageHasNoLabel()
+		{
+			var label = new Label();
+			label.LocalizedLabels.Add(new LocalizedLabel("Chaud", 1036));
+			label.LocalizedLabels.Add(new LocalizedLabel("Hot", 1033));
+
+			Assert.AreEqual("Hot", label.GetTextOrDefault("fallback"));
+		}
+
+		[TestMethod]
+		public void GetTextOrDefault_ShouldFallBackToAnyAvailableLabel()
+		{
+			var label = new Label();
+			label.LocalizedLabels.Add(new LocalizedLabel("Other language", 1031));
+
+			Assert.AreEqual("Other language", label.GetTextOrDefault("fallback"));
+		}
+
+		[TestMethod]
+		public void GetTextOrDefault_ShouldFallBackToDefault_WhenNoLabelIsAvailable()
+		{
+			Assert.AreEqual("fallback", new Label().GetTextOrDefault("fallback"));
+			Assert.AreEqual("fallback", ((Label?)null).GetTextOrDefault("fallback"));
+		}
+
+		[TestMethod]
+		public void GeneratePacxScript_ShouldNotFail_WhenPicklistOptionHasNoUserLocalizedLabel()
+		{
+			var optionSet = new OptionSetMetadata { IsGlobal = false };
+			optionSet.Options.Add(new OptionMetadata(new Label(), 1));
+
+			var otherLanguageOnly = new Label();
+			otherLanguageOnly.LocalizedLabels.Add(new LocalizedLabel("Andere Sprache", 1031));
+			optionSet.Options.Add(new OptionMetadata(otherLanguageOnly, 2));
+
+			var picklist = new PicklistAttributeMetadata
+			{
+				LogicalName = "categorycode",
+				SchemaName = "CategoryCode",
+				OptionSet = optionSet
+			};
+
+			var entity = new Extractor_EntityMetadata
+			{
+				SchemaName = "myprefix_table",
+				DisplayName = "My Table",
+				PluralName = "My Tables",
+				IsCustomEntity = true,
+				Fields = [picklist]
+			};
+
+			var script = new ScriptBuilder().GeneratePacxScript([entity], [], ["myprefix"]);
+
+			StringAssert.Contains(script, "1:1", "The option value must be used when no label is available at all.");
+			StringAssert.Contains(script, "Andere Sprache:2", "A label of another language must be used when the user language has none.");
+		}
+
+		[TestMethod]
+		public void GeneratePacxScript_ShouldNotFail_WhenStateOrStatusOptionHasNoUserLocalizedLabel()
+		{
+			var stateOptions = new OptionSetMetadata();
+			stateOptions.Options.Add(new StateOptionMetadata { Value = 0, DefaultStatus = 1, Label = new Label() });
+			var state = new StateAttributeMetadata { LogicalName = "statecode", OptionSet = stateOptions };
+
+			var statusLabel = new Label();
+			statusLabel.LocalizedLabels.Add(new LocalizedLabel("Aktiv", 1031));
+			var statusOptions = new OptionSetMetadata();
+			statusOptions.Options.Add(new StatusOptionMetadata { Value = 1, State = 0, Label = statusLabel });
+			var status = new StatusAttributeMetadata { LogicalName = "statuscode", OptionSet = statusOptions };
+
+			var entity = new Extractor_EntityMetadata
+			{
+				SchemaName = "myprefix_table",
+				DisplayName = "My Table",
+				PluralName = "My Tables",
+				IsCustomEntity = true,
+				Fields = [state, status]
+			};
+
+			var script = new ScriptBuilder().GeneratePacxScript([entity], [], ["myprefix"]);
+
+			StringAssert.Contains(script, "## STATE: 0", "The state value must be used when the state has no label at all.");
+			StringAssert.Contains(script, "--label Aktiv", "A label of another language must be used for the status option.");
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicateCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Views/ReplicateCommandTest.cs
@@ -10,8 +10,8 @@ namespace Greg.Xrm.Command.Commands.Views
 				"view", "replicate",
 				"--name", "My View",
 				"--table", "account",
-				"--keepcomponents", "true",
-				"--keepsorting", "true");
+				"--keepComponents", "true",
+				"--keepSorting", "true");
 
 			Assert.AreEqual("My View", command.ViewName);
 			Assert.AreEqual("account", command.TableName);


### PR DESCRIPTION
While trying to reproduce #218 I ran pacx script table against the account table on my environment and it died in step 3 with a NullReferenceException. The hang from #218 itself did not reproduce for me, this is a different problem.

The cause is that UserLocalizedLabel is null on options that have no label in the language of the user. My environment is german and some of the first party picklists on account contain options without a german translation. The picklist and the state and status generators dereferenced the label without a check, so the whole command failed for such tables.

The generators now fall back to the english label, then to any available label and finally to the option value. I was not fully sure about the right fallback order here, so happy to change it if you prefer a different behavior. Verified live on my environment, the account run failed before the change and completes after it.

The second commit updates the option names in ReplicateCommandTest to the new casing from 54ad620. The parser is case sensitive, so the test suite did not pass anymore since that change.

Error before:
<img width="392" height="42" alt="image" src="https://github.com/user-attachments/assets/9f29ee07-c40e-43f4-8e75-f9684d54b6db" />
