### PR TITLE
Add 'pacx workflow get' to read the definition of a workflow

### DIFF
--- a/Greg.Xrm.Command.Core/Commands/Workflows/GetCommand.cs
+++ b/Greg.Xrm.Command.Core/Commands/Workflows/GetCommand.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel.DataAnnotations;
+using Greg.Xrm.Command.Parsing;
+using Greg.Xrm.Command.Services;
+
+namespace Greg.Xrm.Command.Commands.Workflows
+{
+	[Command("workflow", "get", HelpText = "Returns the definition of a workflow (Power Automate Flow)")]
+	[Alias("flow", "get")]
+	public class GetCommand : IValidatableObject, ICanProvideUsageExample
+	{
+		[Option("name", "n", Order = 1, HelpText = "The unique name of the workflow to retrieve. Provide either the name or the id.")]
+		public string Name { get; set; } = string.Empty;
+
+		[Option("id", "i", Order = 2, HelpText = "The id of the workflow to retrieve, as found in the url of the flow designer. Provide either the name or the id.")]
+		public Guid? Id { get; set; }
+
+		[Option("solution", "s", Order = 3, HelpText = "The solution that contains the workflow. Only needed when more than one workflow has the same name.")]
+		public string? SolutionName { get; set; }
+
+		[Option("output", "o", Order = 4, HelpText = "If specified, the definition is written to this file instead of the console. The folder must exist.")]
+		public string? OutputFile { get; set; }
+
+
+		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+		{
+			if (string.IsNullOrWhiteSpace(Name) && !Id.HasValue)
+			{
+				yield return new ValidationResult("Please provide either the --name or the --id of the workflow to retrieve.", [nameof(Name), nameof(Id)]);
+			}
+
+			if (!string.IsNullOrWhiteSpace(Name) && Id.HasValue)
+			{
+				yield return new ValidationResult("The --name and the --id arguments cannot be used together.", [nameof(Name), nameof(Id)]);
+			}
+		}
+
+
+		public void WriteUsageExamples(MarkdownWriter writer)
+		{
+			writer.WriteParagraph("This command returns the definition of a single workflow. For a Power Automate Flow that is the json definition with its trigger, actions and connection references, for a classic workflow it is the xaml definition.");
+
+			writer.WriteParagraph("Use ")
+				.WriteCode("pacx workflow list")
+				.Write(" first if you do not know the exact name.");
+
+			writer.WriteCodeBlockStart("Powershell");
+			writer.WriteLine("pacx workflow get --name \"My Flow\"");
+			writer.WriteCodeBlockEnd();
+
+			writer.WriteParagraph("Definitions tend to be large, so you can write them to a file instead of the console. This is handy to compare the same flow between two environments, or to keep it next to the rest of your source code.");
+
+			writer.WriteCodeBlockStart("Powershell");
+			writer.WriteLine("pacx workflow get --name \"My Flow\" --output C:\\temp\\myflow.json");
+			writer.WriteCodeBlockEnd();
+
+			writer.WriteParagraph("If more than one workflow has the same name, you can tell them apart by the solution that contains them.");
+
+			writer.WriteCodeBlockStart("Powershell");
+			writer.WriteLine("pacx workflow get --name \"My Flow\" --solution \"My Solution Name\"");
+			writer.WriteCodeBlockEnd();
+
+			writer.WriteParagraph("You can also use the id instead of the name. It is the second guid in the url when you open a flow in the designer, and it is also shown by ")
+				.WriteCode("pacx workflow list")
+				.Write(".");
+
+			writer.WriteCodeBlockStart("Powershell");
+			writer.WriteLine("pacx workflow get --id 507db5fe-17f1-f011-8406-6045bd95f82d");
+			writer.WriteCodeBlockEnd();
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Commands/Workflows/GetCommandExecutor.cs
+++ b/Greg.Xrm.Command.Core/Commands/Workflows/GetCommandExecutor.cs
@@ -1,0 +1,154 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Greg.Xrm.Command.Model;
+using Greg.Xrm.Command.Services.Connection;
+using Greg.Xrm.Command.Services.Output;
+
+namespace Greg.Xrm.Command.Commands.Workflows
+{
+	public class GetCommandExecutor(
+		IOutput output,
+		IOrganizationServiceRepository organizationServiceRepository,
+		IWorkflowRepository workflowRepository)
+
+	: ICommandExecutor<GetCommand>
+	{
+		public async Task<CommandResult> ExecuteAsync(GetCommand command, CancellationToken cancellationToken)
+		{
+			if (!string.IsNullOrWhiteSpace(command.OutputFile))
+			{
+				string? outputFolder;
+				try
+				{
+					outputFolder = Path.GetDirectoryName(Path.GetFullPath(command.OutputFile));
+				}
+				catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException or IOException)
+				{
+					return CommandResult.Fail($"The output file path <{command.OutputFile}> is not valid: {ex.Message}");
+				}
+
+				if (!string.IsNullOrWhiteSpace(outputFolder) && !Directory.Exists(outputFolder))
+				{
+					return CommandResult.Fail($"The folder <{outputFolder}> does not exist.");
+				}
+			}
+
+			output.Write($"Connecting to the current dataverse environment...");
+			var crm = await organizationServiceRepository.GetCurrentConnectionAsync();
+			output.WriteLine("Done", ConsoleColor.Green);
+
+			var searchedName = command.Name.Trim();
+
+			IReadOnlyList<Workflow> found;
+			try
+			{
+				output.Write($"Retrieving workflow {(command.Id.HasValue ? command.Id.ToString() : searchedName)}...");
+
+				if (command.Id.HasValue)
+				{
+					var byId = await workflowRepository.GetDefinitionByIdAsync(crm, command.Id.Value);
+					found = byId == null ? [] : [byId];
+				}
+				else
+				{
+					found = await workflowRepository.GetDefinitionByNameAsync(crm, searchedName, command.SolutionName?.Trim());
+				}
+
+				output.WriteLine("Done", ConsoleColor.Green);
+			}
+			catch (Exception ex)
+			{
+				output.WriteLine("Failed", ConsoleColor.Red);
+				return CommandResult.Fail(ex.Message, ex);
+			}
+
+			if (found.Count == 0)
+			{
+				var searched = command.Id.HasValue ? $"id <{command.Id}>" : $"name <{searchedName}>";
+				return CommandResult.Fail($"No workflow found with {searched}. You can use 'pacx workflow list' to see the available ones.");
+			}
+
+			// names typed into the maker portal can carry leading or trailing spaces,
+			// so an exact match wins but a name that only differs by those is still found
+			var matches = found;
+			if (!command.Id.HasValue)
+			{
+				var exactMatches = found
+					.Where(w => string.Equals(w.name?.Trim(), searchedName, StringComparison.OrdinalIgnoreCase))
+					.ToList();
+
+				if (exactMatches.Count > 0)
+				{
+					matches = exactMatches;
+				}
+			}
+
+			if (matches.Count > 1)
+			{
+				output.WriteLine();
+				output.WriteLine($"More than one workflow matches <{searchedName}>:", ConsoleColor.Yellow);
+				foreach (var candidate in matches)
+				{
+					output.WriteLine($"  {candidate.name}", ConsoleColor.Yellow);
+				}
+				return CommandResult.Fail("Please provide the full name, or use the --solution option to identify the one you need.");
+			}
+
+			var workflow = matches[0];
+
+			// modern flows keep their definition in clientdata, classic workflows in xaml
+			var definition = !string.IsNullOrWhiteSpace(workflow.clientdata)
+				? Prettify(workflow.clientdata)
+				: workflow.xaml;
+
+			if (string.IsNullOrWhiteSpace(definition))
+			{
+				return CommandResult.Fail($"The workflow <{workflow.name}> ({workflow.CategoryFormatted}) has no definition to return.");
+			}
+
+			if (string.IsNullOrWhiteSpace(command.OutputFile))
+			{
+				output.WriteLine();
+				output.WriteLine(definition);
+				return CommandResult.Success();
+			}
+
+			try
+			{
+				await File.WriteAllTextAsync(command.OutputFile, definition, cancellationToken);
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+				return CommandResult.Fail($"Unable to write the file <{command.OutputFile}>: {ex.Message}");
+			}
+
+			output.WriteLine($"Definition written to {command.OutputFile}", ConsoleColor.Green);
+			return CommandResult.Success();
+		}
+
+		/// <summary>
+		/// The clientdata of a flow is stored as a single line of json.
+		/// Indenting it makes it readable and comparable. The relaxed encoder keeps
+		/// apostrophes and non ascii characters as they are, the output is meant to
+		/// be read and diffed, not to be embedded in html.
+		/// </summary>
+		private static readonly JsonSerializerOptions prettyOptions = new()
+		{
+			WriteIndented = true,
+			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+		};
+
+		private static string Prettify(string json)
+		{
+			try
+			{
+				using var document = JsonDocument.Parse(json);
+				return JsonSerializer.Serialize(document, prettyOptions);
+			}
+			catch (JsonException)
+			{
+				return json;
+			}
+		}
+	}
+}

--- a/Greg.Xrm.Command.Core/Model/IWorkflowRepository.cs
+++ b/Greg.Xrm.Command.Core/Model/IWorkflowRepository.cs
@@ -11,6 +11,10 @@ namespace Greg.Xrm.Command.Model
 		Task<IReadOnlyList<Workflow>> GetByNameAsync(IOrganizationServiceAsync2 crm, string uniqueName);
 		Task<IReadOnlyList<Workflow>> GetBySolutionAsync(IOrganizationServiceAsync2 crm, string solutionUniqueName);
 
+		Task<Workflow?> GetDefinitionByIdAsync(IOrganizationServiceAsync2 crm, Guid id);
+
+		Task<IReadOnlyList<Workflow>> GetDefinitionByNameAsync(IOrganizationServiceAsync2 crm, string name, string? solutionUniqueName);
+
 		Task<IReadOnlyList<Workflow>> SearchByNameAndSolutionAndCategoryAsync(IOrganizationServiceAsync2 crm, string namePart, string? solutionUniqueName, Workflow.Category? category);
 	}
 }

--- a/Greg.Xrm.Command.Core/Model/Workflow.cs
+++ b/Greg.Xrm.Command.Core/Model/Workflow.cs
@@ -7,7 +7,7 @@ namespace Greg.Xrm.Command.Model
 #pragma warning disable IDE1006 // Naming Styles
 	public class Workflow : EntityWrapper
 	{
-		private Workflow(Entity entity) : base(entity)
+		public Workflow(Entity entity) : base(entity)
 		{
 		}
 
@@ -32,6 +32,16 @@ namespace Greg.Xrm.Command.Model
 		public string? CategoryFormatted => GetFormatted(nameof(category));
 
 		public string? xaml
+		{
+			get => Get<string>();
+			set => SetValue(value);
+		}
+
+		/// <summary>
+		/// The definition of a modern flow. Classic workflows store their
+		/// definition in <see cref="xaml"/> instead.
+		/// </summary>
+		public string? clientdata
 		{
 			get => Get<string>();
 			set => SetValue(value);
@@ -122,6 +132,40 @@ namespace Greg.Xrm.Command.Model
 				solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solutionUniqueName);
 				query.NoLock = true;
 
+
+				var result = await crm.RetrieveMultipleAsync(query);
+
+				return [.. result.Entities.Select(x => new Workflow(x))];
+			}
+
+			public async Task<Workflow?> GetDefinitionByIdAsync(IOrganizationServiceAsync2 crm, Guid id)
+			{
+				var query = new QueryExpression("workflow");
+				query.ColumnSet.AddColumns(nameof(Workflow.name), nameof(category), nameof(xaml), nameof(clientdata), nameof(statecode), nameof(statuscode));
+				query.Criteria.AddCondition("workflowid", ConditionOperator.Equal, id);
+				query.NoLock = true;
+
+				var result = await crm.RetrieveMultipleAsync(query);
+
+				return result.Entities.Select(x => new Workflow(x)).FirstOrDefault();
+			}
+
+			public async Task<IReadOnlyList<Workflow>> GetDefinitionByNameAsync(IOrganizationServiceAsync2 crm, string name, string? solutionUniqueName)
+			{
+				var query = new QueryExpression("workflow");
+				query.ColumnSet.AddColumns(nameof(Workflow.name), nameof(category), nameof(xaml), nameof(clientdata), nameof(statecode), nameof(statuscode));
+
+				// names entered in the maker portal can carry leading or trailing spaces,
+				// so the exact match is done on the caller side
+				query.Criteria.AddCondition("name", ConditionOperator.Like, $"%{name}%");
+
+				if (!string.IsNullOrWhiteSpace(solutionUniqueName))
+				{
+					var solutionComponentLink = query.AddLink("solutioncomponent", "workflowid", "objectid");
+					var solutionLink = solutionComponentLink.AddLink("solution", "solutionid", "solutionid");
+					solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solutionUniqueName);
+				}
+				query.NoLock = true;
 
 				var result = await crm.RetrieveMultipleAsync(query);
 

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Workflows/GetCommandExecutorTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Workflows/GetCommandExecutorTest.cs
@@ -1,0 +1,184 @@
+using Greg.Xrm.Command.Model;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+
+namespace Greg.Xrm.Command.Commands.Workflows
+{
+	[TestClass]
+	public class GetCommandExecutorTest : CommandExecutorTestBase
+	{
+		private readonly GetCommandExecutor executor;
+		private readonly Mock<IWorkflowRepository> workflowRepositoryMock = new();
+
+		public GetCommandExecutorTest()
+		{
+			this.executor = new GetCommandExecutor(
+				this.Output,
+				this.OrganizationServiceRepositoryMock.Object,
+				this.workflowRepositoryMock.Object);
+		}
+
+		private const string FlowDefinition = "{\"properties\":{\"definition\":{\"triggers\":{\"manual\":{\"type\":\"Request\"}}}}}";
+
+		private static Workflow CreateWorkflow(Workflow.Category category, string? clientData, string? xaml, string name = "My Flow")
+		{
+			var entity = new Entity("workflow", Guid.NewGuid());
+			entity["name"] = name;
+			entity["category"] = new OptionSetValue((int)category);
+			if (clientData != null) entity["clientdata"] = clientData;
+			if (xaml != null) entity["xaml"] = xaml;
+			return new Workflow(entity);
+		}
+
+		private void SetupWorkflows(params Workflow[] workflows)
+		{
+			this.workflowRepositoryMock
+				.Setup(r => r.GetDefinitionByNameAsync(It.IsAny<IOrganizationServiceAsync2>(), It.IsAny<string>(), It.IsAny<string?>()))
+				.ReturnsAsync(workflows);
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldReturnTheFlowDefinition_Indented()
+		{
+			SetupWorkflows(CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			var written = this.Output.ToString();
+			StringAssert.Contains(written, "\"triggers\"", "The definition must be returned.");
+			StringAssert.Contains(written, Environment.NewLine + "  \"properties\"", "The json must be indented to be readable.");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldKeepApostrophesAndUmlautsReadable()
+		{
+			SetupWorkflows(CreateWorkflow(Workflow.Category.ModernFlow, "{\"text\":\"Grün, it's fine\"}", null));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "Grün, it's fine", "Escaping the definition would make it hard to read and to diff.");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldReturnTheXaml_ForClassicWorkflows()
+		{
+			SetupWorkflows(CreateWorkflow(Workflow.Category.Worfklow, null, "<Activity>test</Activity>"));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "<Activity>test</Activity>");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenNoWorkflowIsFound()
+		{
+			SetupWorkflows();
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "No workflow found");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenTheNameIsNotUnique()
+		{
+			SetupWorkflows(
+				CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null),
+				CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "--solution");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFindTheWorkflow_WhenTheStoredNameHasSurroundingSpaces()
+		{
+			// happens with names that have been typed into the maker portal
+			SetupWorkflows(CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null, " My Flow"));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "\"triggers\"");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldPreferTheExactMatch_OverALongerName()
+		{
+			SetupWorkflows(
+				CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null, "My Flow"),
+				CreateWorkflow(Workflow.Category.ModernFlow, "{\"other\":true}", null, "My Flow v2"));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Name = "My Flow" }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "\"triggers\"");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldReturnTheDefinition_WhenSearchingById()
+		{
+			var id = Guid.NewGuid();
+			this.workflowRepositoryMock
+				.Setup(r => r.GetDefinitionByIdAsync(It.IsAny<IOrganizationServiceAsync2>(), id))
+				.ReturnsAsync(CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null));
+
+			var result = await executor.ExecuteAsync(new GetCommand { Id = id }, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+			StringAssert.Contains(this.Output.ToString(), "\"triggers\"");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenTheIdDoesNotExist()
+		{
+			this.workflowRepositoryMock
+				.Setup(r => r.GetDefinitionByIdAsync(It.IsAny<IOrganizationServiceAsync2>(), It.IsAny<Guid>()))
+				.ReturnsAsync((Workflow?)null);
+
+			var result = await executor.ExecuteAsync(new GetCommand { Id = Guid.NewGuid() }, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "No workflow found with id");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenTheFileCannotBeWritten()
+		{
+			SetupWorkflows(CreateWorkflow(Workflow.Category.ModernFlow, FlowDefinition, null));
+
+			// a directory as target makes the write fail deterministically
+			var command = new GetCommand
+			{
+				Name = "My Flow",
+				OutputFile = Path.GetTempPath()
+			};
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "Unable to write");
+		}
+
+		[TestMethod]
+		public async Task ExecuteAsync_ShouldFail_WhenTheOutputFolderDoesNotExist()
+		{
+			var command = new GetCommand
+			{
+				Name = "My Flow",
+				OutputFile = "C:\\this\\folder\\does\\not\\exist\\at\\all\\myflow.json"
+			};
+
+			var result = await executor.ExecuteAsync(command, CancellationToken.None);
+
+			Assert.IsFalse(result.IsSuccess);
+			StringAssert.Contains(result.ErrorMessage, "does not exist");
+		}
+	}
+}

--- a/test/Greg.Xrm.Command.Core.TestSuite/Commands/Workflows/GetCommandTest.cs
+++ b/test/Greg.Xrm.Command.Core.TestSuite/Commands/Workflows/GetCommandTest.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Greg.Xrm.Command.Commands.Workflows
+{
+	[TestClass]
+	public class GetCommandTest
+	{
+		[TestMethod]
+		public void ParseWithLongNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetCommand>(
+				"workflow", "get",
+				"--name", "My Flow",
+				"--solution", "MySolution",
+				"--output", "C:\\temp\\myflow.json");
+
+			Assert.AreEqual("My Flow", command.Name);
+			Assert.AreEqual("MySolution", command.SolutionName);
+			Assert.AreEqual("C:\\temp\\myflow.json", command.OutputFile);
+		}
+
+		[TestMethod]
+		public void ParseWithShortNamesShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetCommand>(
+				"workflow", "get",
+				"-n", "My Flow");
+
+			Assert.AreEqual("My Flow", command.Name);
+			Assert.IsNull(command.SolutionName);
+			Assert.IsNull(command.OutputFile);
+		}
+
+		[TestMethod]
+		public void ParseWithFlowAliasShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetCommand>(
+				"flow", "get",
+				"-n", "My Flow");
+
+			Assert.AreEqual("My Flow", command.Name);
+		}
+
+		[TestMethod]
+		public void ParseWithIdShouldWork()
+		{
+			var command = Utility.TestParseCommand<GetCommand>(
+				"workflow", "get",
+				"--id", "507db5fe-17f1-f011-8406-6045bd95f82d");
+
+			Assert.AreEqual(Guid.Parse("507db5fe-17f1-f011-8406-6045bd95f82d"), command.Id);
+			Assert.AreEqual(string.Empty, command.Name);
+		}
+
+		[TestMethod]
+		public void ValidateShouldFailWhenNeitherNameNorIdIsProvided()
+		{
+			var command = new GetCommand();
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldFailWhenNameAndIdAreUsedTogether()
+		{
+			var command = new GetCommand { Name = "My Flow", Id = Guid.NewGuid() };
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(1, results.Count);
+		}
+
+		[TestMethod]
+		public void ValidateShouldPassWithNameOnly()
+		{
+			var command = new GetCommand { Name = "My Flow" };
+
+			var results = command.Validate(new ValidationContext(command)).ToList();
+
+			Assert.AreEqual(0, results.Count);
+		}
+	}
+}


### PR DESCRIPTION
Today at work I wanted to look at what one of our flows actually does and would have liked to just pull the definition with pacx, so I implemented it. The workflow group can list, activate and deactivate workflows, but the definition itself was not reachable. For a Power Automate Flow it lives in the clientdata column, which is not read anywhere so far.

The new command returns the definition of a single workflow, either by name or by id, the one from the url of the flow designer. For modern flows that is the json from clientdata, indented so it can be read and compared, for classic workflows it is the xaml. With --output the definition is written to a file, which is handy to diff the same flow between two environments. The console output goes through the renderer which wraps long lines at the console width, so the file is the reliable way when the output should be parsed.

While testing it live I noticed that names typed into the maker portal sometimes carry leading or trailing spaces, so the lookup tolerates them instead of returning nothing for a name that looks correct. When more than one workflow matches, the candidates are listed and --solution can be used to narrow it down.